### PR TITLE
fix(RHTAPWATCH-8): Update GrafanaDashboard to match GrafanaOperator v5

### DIFF
--- a/grafana/dashboard.yaml
+++ b/grafana/dashboard.yaml
@@ -1,44 +1,56 @@
 ---
-apiVersion: integreatly.org/v1alpha1
+apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
   name: kubernetes-cluster-monitoring
   labels:
     app: appstudio-grafana
 spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "appstudio-grafana"
   configMapRef:
     name: kubernetes-cluster-monitoring
     key: kubernetes-cluster-monitoring.json
 ---
-apiVersion: integreatly.org/v1alpha1
+apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
   name: kubernetes-persistent-volumes
   labels: 
     app: appstudio-grafana
 spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "appstudio-grafana"
   configMapRef:
     name: kubernetes-persistent-volumes
     key: kubernetes-persistent-volumes.json
 ---
-apiVersion: integreatly.org/v1alpha1
+apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
   name: pipelineruns-performance
   labels:
     app: appstudio-grafana
 spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "appstudio-grafana"
   configMapRef:
     name: pipelineruns-performance
     key: pipelineruns-performance.json
 ---
-apiVersion: integreatly.org/v1alpha1
+apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
   name: rhtap-performance
   labels:
     app: appstudio-grafana
 spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "appstudio-grafana"
   configMapRef:
     name: rhtap-performance
     key: rhtap-performance.json


### PR DESCRIPTION
As part of this bug fix and the upgrade to `GrafanaOperator` v5, we have to update the `GrafanaDashboard` resource to match the new api

More details:
https://redhat-internal.slack.com/archives/C02CTEB3MMF/p1690371680784569

The dashboard is still presenting data due to a patch we merged to RHTAP, and it will be removed after these changes will be merged