### PR TITLE
Reduce title to just Cluster URL for every individual cluster under every Panel in a Grafana Dashboard

### DIFF
--- a/grafonnet-workdir/src/probes.libsonnet
+++ b/grafonnet-workdir/src/probes.libsonnet
@@ -146,7 +146,7 @@ local pieChart = grafonnet.panel.pieChart;
 
   durationsPanel(testId, fieldNames, fieldUnit, panelName='', extraFilters=[])::
     local title = if panelName == '' then std.join(',', fieldNames) else panelName;
-    timeSeries.new('%s on ${member_cluster}' % title)
+    timeSeries.new('${member_cluster}')
     + timeSeries.queryOptions.withDatasource(
       type='postgres',
       uid='${datasource}',


### PR DESCRIPTION
On Grafana Dashboards for:
1> Single Arch Build (https://grafana.corp.redhat.com/d/Konflux_clusters_loadtest_probe_results/konflux-clusters-loadtest-single-arch-probe-results?from=now-7d&to=now&orgId=26)
2> Multiarch Build (https://grafana.corp.redhat.com/d/Konflux_clusters_loadtest_multi_arch_pr/konflux-clusters-loadtest-multi-arch-probe-results?orgId=26&from=now-7d&to=now) &
3> RPM builds (https://grafana.corp.redhat.com/d/Konflux_clusters_loadtest_RPM_probe_res/konflux-clusters-loadtest-rpm-probe-results?orgId=26)

For every Panel, the title of the panel repeats for every Cluster. Since there are multiple clusters per panel and hence multiple windows per panel, the name/URL of the actual CLUSTER gets hidden. We already know the title from the Panel, so we can avoid the same repetition of title name again before the actual CLUSTER name/URL.

This PR aims to improve that.