### PR TITLE
Add Batch Processing for large number of PODs, also show Median and 90 percentile data

### DIFF
--- a/task-mem-usage-scripts/wrapper_for_promql.sh
+++ b/task-mem-usage-scripts/wrapper_for_promql.sh
@@ -1,54 +1,152 @@
 #!/bin/bash
 
+set -eu -o pipefail
+
 task_name="$1"
 step_name="$2"
 last_num_days="$3"
-user_token="`oc whoami --show-token`"
-prometheus_url="`oc -n openshift-monitoring get route | grep -w 'prometheus-k8s' | grep -v 'federate' | awk '{print $2}'`"
-#task_name="sast-coverity-check-oci-ta"
-#task_name="sast-coverity-check"
-end_time_in_secs=`date +%s`
+batch_size="${4:-50}"   # default batch size = 50
 
-set -eu -o pipefail
+cluster_name="$(oc config current-context | sed -E 's#.*/api-([^-]+-[^-]+-[^-]+).*#\1#')"
+user_token="$(oc whoami --show-token)"
+prometheus_url="$(oc -n openshift-monitoring get route | grep -w 'prometheus-k8s' | grep -v 'federate' | awk '{print $2}')"
+end_time_in_secs="$(date +%s)"
 
-#echo "Current Cluster Context = \"`oc config current-context`\""
-#echo "User Token = $user_token"
-#echo "Prometheus Url = ${prometheus_url}"
-#echo "Querying Task Name = \"${task_name}\""
-#echo "last_num_days = $last_num_days"
-#echo "\"`date`\": start_time_in_secs = $((end_time_in_secs - (last_num_days * 24 * 60 * 60)))"
-#echo "\"`date`\": end_time_in_secs = ${end_time_in_secs}"
+###############################################
+# GET POD LIST
+###############################################
 
-#echo " "
-#read -s -p "Enter any Key to proceed..."
+pod_list_raw="$(
+    python3 list_pods_for_a_particular_task.py \
+        "${user_token}" "${prometheus_url}" "${task_name}" \
+        "${end_time_in_secs}" "${last_num_days}" |
+    jq -r '.data.result[].metric.pod' |
+    sort -u
+)"
 
-#python3 list_pods_for_a_particular_task.py "${user_token}" "${prometheus_url}" "${task_name}" ${end_time_in_secs} | jq .
-#pod_names="`python3 list_pods_for_a_particular_task.py "${user_token}" "${prometheus_url}" "${task_name}" ${end_time_in_secs} | jq . | grep -i '"pod":' | awk {'print $2'} | tr -d '",' | head -1`" #Just the 1st POD for experiment
+pods=()
+while IFS= read -r line; do
+    [ -n "$line" ] && pods+=("$line")
+done <<<"$pod_list_raw"
 
-pod_names="x"
-pod_names="`python3 list_pods_for_a_particular_task.py "${user_token}" "${prometheus_url}" "${task_name}" ${end_time_in_secs} ${last_num_days} | jq . | grep -i '"pod":' | awk {'print $2'} | tr -d '",' | xargs | tr ' ' '|'`" #All the PODs
-
-#echo "Pod Name(s) = \"$pod_names\""
-#step_name="step-use-trusted-artifact"
-#step_name="step-prepare"
-#step_name="step-build"
-#step_name="step-postprocess"
-
-#echo "Container Name = ${step_name}"
-
-#python3 list_container_mem_usage_for_a_particular_pod.py "${user_token}" "${prometheus_url}" "${step_name}" ${end_time_in_secs} ${pod_names}
-
-#Print all values of memory used
-#python3 list_container_mem_usage_for_a_particular_pod.py "${user_token}" "${prometheus_url}" "${step_name}" ${end_time_in_secs} ${pod_names} | grep -v "Enter any Key" | sed '0,/^{/d' | jq '.data.result[].values[][1]'
-
-if [ pod_names != "x" ]; then
-	#Print only the non-zero values
-	max_memory_usage=`python3 list_container_mem_usage_for_a_particular_pod.py "${user_token}" "${prometheus_url}" "${step_name}" ${end_time_in_secs} ${pod_names} ${last_num_days} | grep -v "Enter any Key" | sed '0,/^{/d' | jq '[.data.result[].values[][1] | tonumber | select(. != 0)] | max'`
-	max_memory_usage=$((max_memory_usage/1024/1024))
-	ninety_five_percentile_memory_usage=`python3 list_container_mem_usage_for_a_particular_pod.py "${user_token}" "${prometheus_url}" "${step_name}" ${end_time_in_secs} ${pod_names} ${last_num_days} | grep -v "Enter any Key" | sed '0,/^{/d' | jq '[.data.result[].values[][1] | tonumber | select(. != 0)] as $data | ($data | length) as $length | (($length * 0.95 ) | round) as $index_95thperc | ($data | sort)[$index_95thperc - 1]'`
-	ninety_five_percentile_memory_usage=$((ninety_five_percentile_memory_usage/1024/1024))
-
-	#echo "For Cluster=\"`oc config current-context`\", Task=\"${task_name}\", Container=\"${step_name}\", Max Memory usage in last 24 hours=`echo $((max_memory_usage/1024/1024))` Mb"
-	echo "\"`oc config current-context`\", \"${task_name}\", \"${step_name}\",  max_memory_usage=\"${max_memory_usage} MBytes\", 95_percentile_memory_usage=\"${ninety_five_percentile_memory_usage} MBytes\""
+if [ "${#pods[@]}" -eq 0 ]; then
+    # No Pods found for the task
+    exit 0
 fi
+
+###############################################
+# INITIALIZE GLOBAL ACCUMULATORS
+###############################################
+
+max_overall=0
+perc95_overall=0
+perc90_overall=0
+median_overall=0
+
+###############################################
+# BATCH PROCESSING
+###############################################
+
+total="${#pods[@]}"
+start=0
+
+while [ $start -lt $total ]; do
+    end=$((start + batch_size))
+    [ $end -gt $total ] && end=$total
+
+    batch_pods=""
+    for ((i=start; i<end; i++)); do
+        if [ -z "$batch_pods" ]; then
+            batch_pods="${pods[$i]}"
+        else
+            batch_pods="${batch_pods}|${pods[$i]}"
+        fi
+    done
+
+    ###############################################
+    # RUN PYTHON → GET RAW VALUES IN BYTES
+    ###############################################
+
+    result_json="$(
+        python3 list_container_mem_usage_for_a_particular_pod.py \
+            "${user_token}" "${prometheus_url}" "${step_name}" \
+            "${end_time_in_secs}" "${batch_pods}" "${last_num_days}" |
+        grep -v "Enter any Key" |
+        sed '0,/^{/d'
+    )"
+
+    ###############################################
+    # CALCULATE METRICS
+    ###############################################
+
+    max_memory_usage="$(echo "$result_json" | jq '[.data.result[].values[][1] | tonumber | select(. != 0)] | max')"
+
+    perc95="$(echo "$result_json" | jq '
+        [.data.result[].values[][1] | tonumber | select(. != 0)] as $data |
+        ($data | length) as $N |
+        if $N == 0 then 0 else
+            (($N * 0.95) | round) as $i |
+            ($data | sort)[$i - 1]
+        end
+    ')"
+
+    perc90="$(echo "$result_json" | jq '
+        [.data.result[].values[][1] | tonumber | select(. != 0)] as $data |
+        ($data | length) as $N |
+        if $N == 0 then 0 else
+            (($N * 0.90) | round) as $i |
+            ($data | sort)[$i - 1]
+        end
+    ')"
+
+    median="$(echo "$result_json" | jq '
+        [.data.result[].values[][1] | tonumber | select(. != 0)] as $data |
+        ($data | length) as $N |
+        if $N == 0 then 0 else
+            ($data | sort) as $s |
+            if ($N % 2 == 1) then
+                $s[($N/2 | floor)]
+            else
+                (($s[($N/2 - 1)] + $s[($N/2)]) / 2)
+            end
+        end
+    ')"
+
+    ###############################################
+    # NULL → 0 FIX
+    ###############################################
+
+    for var in max_memory_usage perc95 perc90 median; do
+        eval "v=\${$var}"
+        [ "$v" = "null" ] && eval "$var=0"
+    done
+
+    ###############################################
+    # CONVERT BYTES → MB
+    ###############################################
+
+    max_memory_usage=$((max_memory_usage/1024/1024))
+    perc95=$((perc95/1024/1024))
+    perc90=$((perc90/1024/1024))
+    median=$((median/1024/1024))
+
+    ###############################################
+    # GLOBAL ACCUMULATION (MAX ACROSS BATCHES)
+    ###############################################
+
+    (( max_memory_usage > max_overall )) && max_overall="$max_memory_usage"
+    (( perc95 > perc95_overall )) && perc95_overall="$perc95"
+    (( perc90 > perc90_overall )) && perc90_overall="$perc90"
+    (( median > median_overall )) && median_overall="$median"
+
+    start=$((start + batch_size))
+done
+
+###############################################
+# FINAL OUTPUT
+###############################################
+
+echo "cluster_name=\"${cluster_name}\", task_name=\"${task_name}\", step_name=\"${step_name}\", \
+Max_mem=\"${max_overall} MB\", 95_Pctl_Mem=\"${perc95_overall} MB\", \
+90_Pctl_Mem=\"${perc90_overall} MB\", Median_Mem=\"${median_overall} MB\""
 


### PR DESCRIPTION
For tasks returning very large number of PODs, the next call to list_container_mem_usage_for_a_particular_pod.py was failing as Prometheus is not able to handle such a large string of PODs.

This PR introduces batch processing with default POD size of 50, which was found to be helpful. So, Prometheus will be called total_num_pods/batch_size times to gather overall data, which then will be used to generate the following information:

1. Max Memory Usage
2. 95 percentile memory usage
3. 90 percentile memory usage
4. Median memory usage as well

Last 7 days data generated using the updated logic:
```
% ./wrapper_for_promql_for_all_clusters.sh 7
cluster_name="kflux-prd-rh02", task_name="sast-coverity-check-oci-ta", step_name="step-use-trusted-artifact", Max_mem="4098 MB", 95_Pctl_Mem="4098 MB", 90_Pctl_Mem="4098 MB", Median_Mem="4097 MB"
cluster_name="kflux-prd-rh02", task_name="sast-coverity-check-oci-ta", step_name="step-prepare", Max_mem="11 MB", 95_Pctl_Mem="10 MB", 90_Pctl_Mem="10 MB", Median_Mem="8 MB"
cluster_name="kflux-prd-rh02", task_name="sast-coverity-check-oci-ta", step_name="step-build", Max_mem="16385 MB", 95_Pctl_Mem="16384 MB", 90_Pctl_Mem="16384 MB", Median_Mem="6875 MB"
cluster_name="kflux-prd-rh02", task_name="sast-coverity-check-oci-ta", step_name="step-postprocess", Max_mem="14947 MB", 95_Pctl_Mem="13648 MB", 90_Pctl_Mem="12911 MB", Median_Mem="6494 MB"
cluster_name="kflux-prd-rh03", task_name="sast-coverity-check-oci-ta", step_name="step-use-trusted-artifact", Max_mem="12 MB", 95_Pctl_Mem="11 MB", 90_Pctl_Mem="10 MB", Median_Mem="8 MB"
cluster_name="kflux-prd-rh03", task_name="sast-coverity-check-oci-ta", step_name="step-prepare", Max_mem="1 MB", 95_Pctl_Mem="1 MB", 90_Pctl_Mem="1 MB", Median_Mem="0 MB"
cluster_name="kflux-prd-rh03", task_name="sast-coverity-check-oci-ta", step_name="step-build", Max_mem="15994 MB", 95_Pctl_Mem="15733 MB", 90_Pctl_Mem="15646 MB", Median_Mem="11610 MB"
cluster_name="kflux-prd-rh03", task_name="sast-coverity-check-oci-ta", step_name="step-postprocess", Max_mem="32 MB", 95_Pctl_Mem="10 MB", 90_Pctl_Mem="10 MB", Median_Mem="8 MB"
cluster_name="stone-prd-rh01", task_name="sast-coverity-check-oci-ta", step_name="step-use-trusted-artifact", Max_mem="4648 MB", 95_Pctl_Mem="2495 MB", 90_Pctl_Mem="2495 MB", Median_Mem="1217 MB"
cluster_name="stone-prd-rh01", task_name="sast-coverity-check-oci-ta", step_name="step-prepare", Max_mem="10 MB", 95_Pctl_Mem="10 MB", 90_Pctl_Mem="10 MB", Median_Mem="9 MB"
cluster_name="stone-prd-rh01", task_name="sast-coverity-check-oci-ta", step_name="step-build", Max_mem="16384 MB", 95_Pctl_Mem="16384 MB", 90_Pctl_Mem="13386 MB", Median_Mem="11862 MB"
cluster_name="stone-prd-rh01", task_name="sast-coverity-check-oci-ta", step_name="step-postprocess", Max_mem="13534 MB", 95_Pctl_Mem="12840 MB", 90_Pctl_Mem="12365 MB", Median_Mem="8560 MB"
cluster_name="stone-prod-p02", task_name="sast-coverity-check-oci-ta", step_name="step-use-trusted-artifact", Max_mem="3509 MB", 95_Pctl_Mem="2743 MB", 90_Pctl_Mem="1396 MB", Median_Mem="17 MB"
cluster_name="stone-prod-p02", task_name="sast-coverity-check-oci-ta", step_name="step-prepare", Max_mem="10 MB", 95_Pctl_Mem="10 MB", 90_Pctl_Mem="8 MB", Median_Mem="7 MB"
cluster_name="stone-prod-p02", task_name="sast-coverity-check-oci-ta", step_name="step-build", Max_mem="16384 MB", 95_Pctl_Mem="16384 MB", 90_Pctl_Mem="16384 MB", Median_Mem="13843 MB"
cluster_name="stone-prod-p02", task_name="sast-coverity-check-oci-ta", step_name="step-postprocess", Max_mem="9234 MB", 95_Pctl_Mem="8693 MB", 90_Pctl_Mem="8584 MB", Median_Mem="6407 MB"
```

Cc: @jhutar