### PR TITLE
Add new tool for detecting OOMKilled and CrashloopBackoff PODs across any Konflux/Kubernetes cluster(s)

### DIFF
--- a/oomkill-and-crashloopbackoff-detector/README.md
+++ b/oomkill-and-crashloopbackoff-detector/README.md
@@ -1,0 +1,473 @@
+# OOMKilled / CrashLoopBackOff detector (oc_get_ooms.py)
+
+A high-performance, parallel OOMKilled / CrashLoopBackOff detector for OpenShift & Kubernetes clusters using `oc`, with optional Prometheus fallback, rich exports, and forensic artifact collection.
+
+---
+
+## 🚀 What This Tool Does
+
+- Scans **one or many OpenShift clusters** (`oc` contexts)
+- Detects:
+  - **OOMKilled pods**
+  - **CrashLoopBackOff pods**
+- Looks back across **multiple time windows**:
+  - 1h, 3h, 6h, 24h, 48h, 3d, 5d, 7d
+- Uses:
+  - Kubernetes **events** first (fast)
+  - **Prometheus fallback** for older history
+- Runs **highly parallel**:
+  - Cluster-level batching
+  - Namespace-level batching
+- Saves **forensic artifacts**:
+  - `oc describe pod`
+  - `oc logs` (or `--previous`)
+- Exports **CSV + JSON** with absolute paths to artifacts
+- Colorized terminal output
+
+---
+
+## 🧠 Architecture Overview
+
+```text
+                         ┌────────────────────────┐
+                         │  oc config get-contexts│
+                         └────────────┬───────────┘
+                                      │
+                       Context batching (N clusters)
+                                      │
+          ┌───────────────────────────┴─────────────────────────────┐
+          │                                                         │
+┌─────────▼─────────┐                                     ┌─────────▼─────────┐
+│  Cluster Worker   │                                     │  Cluster Worker   │
+│ (context A)       │                                     │ (context B)       │
+└─────────┬─────────┘                                     └─────────┬─────────┘
+          │                                                         │
+  Fetch namespaces                                            Fetch namespaces
+          │                                                         │
+ Namespace batching (10 default)                             Namespace batching
+          │                                                         │
+┌─────────▼─────────┐                                     ┌─────────▼─────────┐
+│ Namespace Workers │  (parallel)                         │ Namespace Workers │
+│  oc get events    │                                     │  oc get events    │
+│  detect OOM / CLB │                                     │  detect OOM / CLB │
+└─────────┬─────────┘                                     └─────────┬─────────┘
+          │                                                         │
+ If older data needed                                   If older data needed
+          │                                                         │
+┌─────────▼─────────┐                                     ┌─────────▼─────────┐
+│Prometheus Fallback│  (batched + parallel)               │Prometheus Fallback│
+└─────────┬─────────┘                                     └─────────┬─────────┘
+          │                                                         │
+ Save artifacts:                                              Save artifacts:
+ - pod describe                                               - pod describe
+ - pod logs / previous                                        - pod logs / previous
+          │                                                         │
+┌─────────▼─────────┐                                     ┌─────────▼─────────┐
+│ CSV / JSON Export │                                     │ CSV / JSON Export │
+└───────────────────┘                                     └───────────────────┘
+```
+
+---
+
+## ⚙️ Parallelism Model
+
+| Layer            | Default | Controlled By |
+|------------------|---------|---------------|
+| Cluster batching | 2       | `--batch-size` |
+| Namespace batch  | 10      | `--ns-batch-size` |
+| Namespace workers| 5       | `--ns-workers` |
+| Prometheus batch | Same as namespace batch | `--ns-batch-size` |
+
+Prometheus fallback is **bounded and safe** for large clusters.
+
+---
+
+## 📂 Artifact Storage Layout
+
+Artifacts are stored **per cluster**:
+
+```
+/tmp/<cluster_name>/
+  <namespace>__<pod>__<timestamp>__desc.txt
+  <namespace>__<pod>__<timestamp>__log.txt
+```
+
+Example:
+
+```
+/tmp/kflux-prd-es01/
+  clusters-a53fda0e...__catalog-operator__2025-12-12T05-25-40Z__desc.txt
+  clusters-a53fda0e...__catalog-operator__2025-12-12T05-25-40Z__log.txt
+```
+
+If `oc logs` returns no data, the tool automatically retries with:
+
+```
+oc logs --previous
+```
+
+---
+
+## 📤 Output Formats
+
+### CSV Columns
+
+```
+cluster,
+namespace,
+pod,
+type,
+timestamps,
+sources,
+description_file,
+pod_log_file
+```
+
+### JSON Structure (simplified)
+
+```json
+{
+  "cluster": "kflux-prd-es01",
+  "namespace": "clusters-a53fda0e...",
+  "pod": "catalog-operator-79c5668759-hfrq8",
+  "type": "CrashLoopBackOff",
+  "timestamps": [
+    "2025-12-12T05:25:40Z"
+  ],
+  "sources": ["events"],
+  "artifacts": {
+    "description_file": "/tmp/kflux-prd-es01/...__desc.txt",
+    "pod_log_file": "/tmp/kflux-prd-es01/...__log.txt"
+  }
+}
+```
+
+---
+
+## 🧪 Example Runs
+
+### Run on current context only
+
+```bash
+./oc_get_ooms.py --current
+```
+
+### Run on specific contexts
+
+```bash
+./oc_get_ooms.py \
+  --contexts default/api-stone-prd-rh01...,default/api-kflux-prd...
+```
+
+### Run on all contexts (default)
+
+```bash
+./oc_get_ooms.py
+```
+
+### High-performance mode for very large clusters
+
+```bash
+./oc_get_ooms.py \
+  --batch-size 3 \
+  --ns-batch-size 20 \
+  --ns-workers 10
+```
+
+### Skip Prometheus fallback
+
+```bash
+./oc_get_ooms.py --skip-prometheus
+```
+
+### Namespace filtering (regex)
+
+Only namespaces containing `tenant`, exclude `test`:
+
+```bash
+./oc_get_ooms.py \
+  --include-ns tenant \
+  --exclude-ns test
+```
+
+Multiple regex patterns:
+
+```bash
+./oc_get_ooms.py \
+  --include-ns "tenant|prod" \
+  --exclude-ns "debug|sandbox"
+```
+
+---
+
+## 🎨 Terminal Output
+
+- **Green** → no issues
+- **Yellow** → namespace scanned
+- **Red** → OOM / CrashLoopBackOff detected
+- **Cyan** → cluster boundaries
+- **Gray** → skipped or unreachable clusters
+
+---
+
+## 🛡️ Resilience & Safety
+
+- Retries on TLS / API failures
+- Configurable timeouts
+- Graceful skipping of unreachable clusters
+- Prometheus rate-safe batching
+- Namespaces printed **only if issues are found**
+
+---
+
+## 📌 Requirements
+
+- Python **3.9+**
+- `oc` CLI in PATH
+- Logged in (`oc whoami` must succeed)
+- Prometheus access (optional)
+
+---
+
+## 📄 Files Generated
+
+| File | Purpose |
+|------|---------|
+| `oom_results.csv` | Spreadsheet-friendly output |
+| `oom_results.json` | Structured automation input |
+| `/tmp/<cluster>/*.txt` | Pod forensic artifacts |
+
+---
+
+## 🧠 Design Philosophy
+
+> **Fast, safe, forensic-grade, and cluster-scale.**
+
+---
+
+## 📝 License
+
+Internal / Team Utility  
+Adapt as needed.
+
+---
+
+## 🔮 Future Enhancements & Roadmap
+
+The following enhancements are **intentionally planned** and align with the current architecture.
+Most can be added incrementally without redesigning the tool.
+
+---
+
+### 📈 1. OOM / CrashLoopBackOff Trend Analysis
+
+Analyze **patterns over time** across:
+
+- Namespaces
+- Clusters
+- Workloads
+- Time windows
+
+Examples:
+
+- Which namespaces OOM most frequently?
+- Which clusters are most unstable?
+- Are OOMs increasing week-over-week?
+- Which pods repeatedly crash after restarts?
+
+#### Possible Outputs
+
+```text
+Cluster          Namespace        OOMs(7d)  CLB(7d)  Trend
+----------------------------------------------------------
+kflux-prd-es01   tenant-a         24        3        ↑↑
+kflux-prd-es01   tenant-b         2         15       ↑
+stone-prd-rh01   tenant-x         0         8        →
+```
+
+This can be implemented by:
+- Persisting JSON outputs across runs
+- Aggregating by `(cluster, namespace, pod)`
+- Applying rolling time windows (7d / 30d)
+
+---
+
+### 📊 2. Namespace Stability Scoring
+
+Compute a **stability score** per namespace:
+
+```text
+score = f(OOM count, CrashLoop count, restart frequency)
+```
+
+Example:
+
+```text
+Namespace        Score   Status
+--------------------------------
+tenant-prod-a    92      Stable
+tenant-prod-b    61      Warning
+tenant-prod-c    28      Critical
+```
+
+This allows:
+- Ranking tenants
+- Capacity planning
+- SLO enforcement
+
+---
+
+### 🧠 3. Memory Pressure Correlation
+
+Correlate OOMs with:
+- Container memory limits
+- Actual memory usage (Prometheus)
+- Node memory pressure
+
+Answer questions like:
+- Are OOMs caused by under-sized limits?
+- Are multiple namespaces competing on the same nodes?
+- Do OOMs align with traffic spikes?
+
+---
+
+### 📉 4. Historical Baseline & Regression Detection
+
+Automatically detect regressions:
+
+- “Namespace X normally has 0–1 OOMs/week, now has 12”
+- “CrashLoopBackOff appeared after deployment Y”
+
+This could integrate with:
+- Deployment timestamps
+- Image changes
+- ConfigMap updates
+
+---
+
+### 🧾 5. Persistent Storage Backend
+
+Optional persistence layer:
+
+- SQLite (local)
+- PostgreSQL
+- S3 / Object Storage
+
+Use cases:
+- Long-term trend analysis
+- Dashboards
+- Audit trails
+
+---
+
+### 📊 6. HTML / Web Report Generation
+
+Generate:
+- Static HTML reports
+- Per-cluster dashboards
+- Per-namespace drilldowns
+
+Example command:
+
+```bash
+./oc_get_ooms.py --html-report out.html
+```
+
+---
+
+### 📡 7. Alerting & Integrations
+
+Integrations could include:
+
+- Slack
+- Email
+- PagerDuty
+- Jira / ServiceNow
+- GitHub Issues
+
+Example:
+```text
+ALERT: tenant-prod-x had 5 OOMs in last 6h on cluster kflux-prd-es01
+```
+
+---
+
+### 📍 8. Grafana Annotations
+
+Automatically annotate Grafana dashboards when:
+- OOMs occur
+- CrashLoopBackOff starts
+- Thresholds are exceeded
+
+This links incidents directly to metrics timelines.
+
+---
+
+### 🧪 9. Canary / Deployment Awareness
+
+Enhance detection by:
+- Linking OOMs to recent rollouts
+- Identifying bad canary deployments
+- Comparing old vs new ReplicaSets
+
+---
+
+### 🧵 10. Event Deduplication & Root Cause Grouping
+
+Group related failures:
+
+- Same pod template
+- Same container
+- Same error signature
+
+Example:
+
+```text
+Root Cause: insufficient memory limit (256Mi)
+Affected Pods: 17
+Affected Namespaces: 4
+```
+
+---
+
+### 🔐 11. RBAC & Least-Privilege Mode
+
+Add flags for:
+- Namespace-scoped scanning
+- Read-only operation
+- Limited artifact collection
+
+Useful for:
+- Tenant self-service diagnostics
+- Restricted environments
+
+---
+
+### 🧩 12. Plugin Architecture
+
+Enable pluggable detectors:
+
+```text
+detectors/
+  oom.py
+  crashloop.py
+  diskpressure.py
+  cpuhog.py
+```
+
+Allow teams to add custom failure modes without modifying core logic.
+
+---
+
+## 🧠 Long-Term Vision
+
+> Move from **reactive troubleshooting** → **predictive reliability insights**
+
+This tool can evolve into:
+- A fleet-wide reliability scanner
+- A capacity planning assistant
+- An SRE forensic toolkit
+
+---
+
+

--- a/oomkill-and-crashloopbackoff-detector/oc_get_ooms.py
+++ b/oomkill-and-crashloopbackoff-detector/oc_get_ooms.py
@@ -27,6 +27,7 @@ import csv
 import re
 import sys
 import time
+import logging
 from datetime import datetime
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
@@ -35,14 +36,16 @@ from typing import List, Dict, Any, Tuple, Optional, Set, Pattern
 # ---------------------------
 # Color output
 # ---------------------------
-RED    = "\033[1;31m"
-GREEN  = "\033[1;32m"
+RED = "\033[1;31m"
+GREEN = "\033[1;32m"
 YELLOW = "\033[1;33m"
-BLUE   = "\033[1;34m"
-RESET  = "\033[0m"
+BLUE = "\033[1;34m"
+RESET = "\033[0m"
+
 
 def color(text: str, c: str) -> str:
     return f"{c}{text}{RESET}"
+
 
 # ---------------------------
 # Time windows (kept for context; not used directly for artifact collection)
@@ -58,8 +61,14 @@ TIME_WINDOWS = {
     "last_7d": 168,
 }
 
-PROMQL_OOM = 'kube_pod_container_status_last_terminated_reason{{reason="OOMKilled",namespace="{namespace}"}}'
-PROMQL_CRASH = 'kube_pod_container_status_waiting_reason{{reason="CrashLoopBackOff",namespace="{namespace}"}}'
+PROMQL_OOM = (
+    "kube_pod_container_status_last_terminated_reason"
+    '{{reason="OOMKilled",namespace="{namespace}"}}'
+)
+PROMQL_CRASH = (
+    "kube_pod_container_status_waiting_reason"
+    '{{reason="CrashLoopBackOff",namespace="{namespace}"}}'
+)
 
 # ---------------------------
 # Defaults
@@ -69,18 +78,28 @@ DEFAULT_OC_TIMEOUT = 45  # seconds
 RETRY_DELAY_SECONDS = 3
 DEFAULT_NS_BATCH_SIZE = 10
 DEFAULT_NS_WORKERS = 5
+DEFAULT_BATCH_SIZE = 2
+
+# Prometheus constants
+PROMETHEUS_NAMESPACE = "openshift-monitoring"
+PROMETHEUS_LABEL_SELECTOR = "app=prometheus"
+PROMETHEUS_PORT = 9090
+
 
 # ---------------------------
 # Command runner with retries
 # ---------------------------
-def run_cmd_with_retries(cmd: List[str], retries: int = DEFAULT_RETRIES, timeout: Optional[int] = None
-                         ) -> Tuple[int, str, str]:
+def run_cmd_with_retries(
+    cmd: List[str], retries: int = DEFAULT_RETRIES, timeout: Optional[int] = None
+) -> Tuple[int, str, str]:
     attempt = 0
     last_err = ""
     while attempt < max(1, retries):
         attempt += 1
         try:
-            completed = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+            completed = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=timeout
+            )
             stdout = (completed.stdout or "").strip()
             stderr = (completed.stderr or "").strip()
             return completed.returncode, stdout, stderr
@@ -92,83 +111,122 @@ def run_cmd_with_retries(cmd: List[str], retries: int = DEFAULT_RETRIES, timeout
             time.sleep(RETRY_DELAY_SECONDS * attempt)
     return 1, "", last_err
 
-def run_shell_cmd_with_retries(cmd: str, retries: int = DEFAULT_RETRIES, timeout: Optional[int] = None
-                               ) -> Tuple[int, str, str]:
-    return run_cmd_with_retries(["/bin/sh", "-c", cmd], retries=retries, timeout=timeout)
+
+def run_shell_cmd_with_retries(
+    cmd: str, retries: int = DEFAULT_RETRIES, timeout: Optional[int] = None
+) -> Tuple[int, str, str]:
+    return run_cmd_with_retries(
+        ["/bin/sh", "-c", cmd], retries=retries, timeout=timeout
+    )
+
 
 # ---------------------------
 # oc helpers
 # ---------------------------
-def oc_cmd_parts(context: str, oc_timeout_seconds: int, subcommand: List[str]) -> List[str]:
+def oc_cmd_parts(
+    context: str, oc_timeout_seconds: int, subcommand: List[str]
+) -> List[str]:
     parts = ["oc", f"--request-timeout={oc_timeout_seconds}s"]
     if context:
         parts += ["--context", context]
     parts += subcommand
     return parts
 
-def run_oc_subcommand(context: str, subcommand: List[str], retries: int, oc_timeout_seconds: int
-                     ) -> Tuple[int, str, str]:
+
+def run_oc_subcommand(
+    context: str, subcommand: List[str], retries: int, oc_timeout_seconds: int
+) -> Tuple[int, str, str]:
     cmd = oc_cmd_parts(context, oc_timeout_seconds, subcommand)
     return run_cmd_with_retries(cmd, retries=retries, timeout=oc_timeout_seconds + 5)
+
 
 # ---------------------------
 # context utilities
 # ---------------------------
 def get_all_contexts(retries: int, oc_timeout_seconds: int) -> List[str]:
-    rc, out, err = run_shell_cmd_with_retries("oc config get-contexts -o name", retries=retries, timeout=oc_timeout_seconds + 5)
+    """Get all available OpenShift contexts."""
+    cmd = ["oc", "config", "get-contexts", "-o", "name"]
+    rc, out, err = run_cmd_with_retries(
+        cmd, retries=retries, timeout=oc_timeout_seconds + 5
+    )
     if rc != 0 or not out:
         return []
     return [line.strip() for line in out.splitlines() if line.strip()]
 
+
 def get_current_context(retries: int, oc_timeout_seconds: int) -> str:
-    rc, out, err = run_shell_cmd_with_retries("oc config current-context", retries=retries, timeout=oc_timeout_seconds + 5)
+    """Get the current OpenShift context."""
+    cmd = ["oc", "config", "current-context"]
+    rc, out, err = run_cmd_with_retries(
+        cmd, retries=retries, timeout=oc_timeout_seconds + 5
+    )
     return out.strip() if rc == 0 else ""
+
 
 def short_cluster_name(full_ctx: str) -> str:
     m = re.search(r"api-([^-]+-[^-]+-[^-]+)", full_ctx)
     if m:
         return m.group(1)
-    if '/' in full_ctx:
-        return full_ctx.split('/')[-1]
-    return full_ctx.replace('/', '_').replace(':', '_')
+    if "/" in full_ctx:
+        return full_ctx.split("/")[-1]
+    return full_ctx.replace("/", "_").replace(":", "_")
+
 
 # ---------------------------
 # timestamp utilities
 # ---------------------------
 def parse_timestamp_to_iso(ts: str) -> str:
+    """Parse Kubernetes timestamp to ISO format."""
     if not ts:
         return ""
     try:
         base = ts.split(".")[0].rstrip("Z")
         dt = datetime.strptime(base, "%Y-%m-%dT%H:%M:%S")
         return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
-    except Exception:
+    except (ValueError, AttributeError) as e:
+        logging.debug(f"Failed to parse timestamp '{ts}': {e}")
         return ts
+
 
 def now_ts_for_filename() -> str:
     return datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
 
+
 # ---------------------------
 # connectivity
 # ---------------------------
-def check_cluster_connectivity(context: str, retries: int, oc_timeout_seconds: int) -> Tuple[bool, str]:
-    rc, out, err = run_oc_subcommand(context, ["whoami"], retries=retries, oc_timeout_seconds=oc_timeout_seconds)
+def check_cluster_connectivity(
+    context: str, retries: int, oc_timeout_seconds: int
+) -> Tuple[bool, str]:
+    rc, out, err = run_oc_subcommand(
+        context, ["whoami"], retries=retries, oc_timeout_seconds=oc_timeout_seconds
+    )
     if rc == 0:
         return True, ""
     return False, err or out or "unknown error"
 
+
 # ---------------------------
 # oc-only namespace workers (no Prometheus here)
 # ---------------------------
-def find_events_by_reason_oc(context: str, namespace: str, reason_substring: str,
-                             retries: int, oc_timeout_seconds: int) -> List[Dict[str, str]]:
+def find_events_by_reason_oc(
+    context: str,
+    namespace: str,
+    reason_substring: str,
+    retries: int,
+    oc_timeout_seconds: int,
+) -> List[Dict[str, str]]:
+    """Find events matching a reason substring in a namespace."""
     subcmd = ["-n", namespace, "get", "events", "--ignore-not-found", "-o", "json"]
-    rc, out, err = run_oc_subcommand(context, subcmd, retries=retries, oc_timeout_seconds=oc_timeout_seconds)
+    rc, out, err = run_oc_subcommand(
+        context, subcmd, retries=retries, oc_timeout_seconds=oc_timeout_seconds
+    )
     if rc != 0 or not out:
         return []
     try:
         obj = json.loads(out)
-    except Exception:
+    except json.JSONDecodeError as e:
+        logging.warning(f"Failed to parse events JSON for {namespace}: {e}")
         return []
     res: List[Dict[str, str]] = []
     for ev in obj.get("items", []):
@@ -178,17 +236,26 @@ def find_events_by_reason_oc(context: str, namespace: str, reason_substring: str
         pod = ev.get("involvedObject", {}).get("name")
         ts = ev.get("eventTime") or ev.get("lastTimestamp") or ev.get("firstTimestamp")
         if pod and ts:
-            res.append({"pod": pod, "reason": reason, "timestamp": parse_timestamp_to_iso(ts)})
+            res.append(
+                {"pod": pod, "reason": reason, "timestamp": parse_timestamp_to_iso(ts)}
+            )
     return res
 
-def crashloop_via_pods_oc(context: str, namespace: str, retries: int, oc_timeout_seconds: int) -> List[Dict[str, str]]:
+
+def crashloop_via_pods_oc(
+    context: str, namespace: str, retries: int, oc_timeout_seconds: int
+) -> List[Dict[str, str]]:
+    """Find pods in CrashLoopBackOff state by querying pod status."""
     subcmd = ["-n", namespace, "get", "pods", "-o", "json", "--ignore-not-found"]
-    rc, out, err = run_oc_subcommand(context, subcmd, retries=retries, oc_timeout_seconds=oc_timeout_seconds)
+    rc, out, err = run_oc_subcommand(
+        context, subcmd, retries=retries, oc_timeout_seconds=oc_timeout_seconds
+    )
     if rc != 0 or not out:
         return []
     try:
         obj = json.loads(out)
-    except Exception:
+    except json.JSONDecodeError as e:
+        logging.warning(f"Failed to parse pods JSON for {namespace}: {e}")
         return []
     res: List[Dict[str, str]] = []
     for item in obj.get("items", []):
@@ -197,26 +264,73 @@ def crashloop_via_pods_oc(context: str, namespace: str, retries: int, oc_timeout
         for cs in statuses:
             waiting = cs.get("state", {}).get("waiting")
             if waiting and waiting.get("reason") == "CrashLoopBackOff":
-                res.append({"pod": pod_name, "reason": "CrashLoopBackOff", "timestamp": ""})
+                res.append(
+                    {"pod": pod_name, "reason": "CrashLoopBackOff", "timestamp": ""}
+                )
     return res
+
 
 # ---------------------------
 # Prometheus fallback (can be parallelized in batches)
 # ---------------------------
-def prom_query_from_prometheus_pod(context: str, namespace: str, promql: str,
-                                   retries: int, oc_timeout_seconds: int) -> List[Dict[str, str]]:
-    find_cmd = f'oc --request-timeout={oc_timeout_seconds}s --context="{context}" -n openshift-monitoring get pod -l app=prometheus -o name | head -1'
-    rc, pod_name, err = run_shell_cmd_with_retries(find_cmd, retries=retries, timeout=oc_timeout_seconds + 5)
-    if rc != 0 or not pod_name:
+def prom_query_from_prometheus_pod(
+    context: str, namespace: str, promql: str, retries: int, oc_timeout_seconds: int
+) -> List[Dict[str, str]]:
+    """Query Prometheus via exec into prometheus pod."""
+    # Find prometheus pod using oc command (safer than shell string)
+    find_cmd = oc_cmd_parts(
+        context,
+        oc_timeout_seconds,
+        [
+            "-n",
+            PROMETHEUS_NAMESPACE,
+            "get",
+            "pod",
+            "-l",
+            PROMETHEUS_LABEL_SELECTOR,
+            "-o",
+            "name",
+        ],
+    )
+    rc, out, err = run_cmd_with_retries(
+        find_cmd, retries=retries, timeout=oc_timeout_seconds + 5
+    )
+    if rc != 0 or not out:
         return []
-    query_encoded = promql.replace('"', '\\"')
-    exec_cmd = f'oc --request-timeout={oc_timeout_seconds}s --context="{context}" -n openshift-monitoring exec {pod_name} -- curl -s -G http://localhost:9090/api/v1/query --data-urlencode "query={query_encoded}"'
-    rc2, out2, err2 = run_shell_cmd_with_retries(exec_cmd, retries=retries, timeout=oc_timeout_seconds + 10)
+    # Get first pod name (strip "pod/" prefix if present)
+    pod_lines = [line.strip() for line in out.splitlines() if line.strip()]
+    if not pod_lines:
+        return []
+    pod_name = pod_lines[0].replace("pod/", "")
+
+    # Build curl command safely using subprocess arguments
+    curl_url = f"http://localhost:{PROMETHEUS_PORT}/api/v1/query"
+    exec_cmd = oc_cmd_parts(
+        context,
+        oc_timeout_seconds,
+        [
+            "-n",
+            PROMETHEUS_NAMESPACE,
+            "exec",
+            pod_name,
+            "--",
+            "curl",
+            "-s",
+            "-G",
+            curl_url,
+            "--data-urlencode",
+            f"query={promql}",
+        ],
+    )
+    rc2, out2, err2 = run_cmd_with_retries(
+        exec_cmd, retries=retries, timeout=oc_timeout_seconds + 10
+    )
     if rc2 != 0 or not out2:
         return []
     try:
         resp = json.loads(out2)
-    except Exception:
+    except json.JSONDecodeError as e:
+        logging.warning(f"Failed to parse Prometheus response for {namespace}: {e}")
         return []
     res: List[Dict[str, str]] = []
     for r in resp.get("data", {}).get("result", []):
@@ -226,21 +340,34 @@ def prom_query_from_prometheus_pod(context: str, namespace: str, promql: str,
             res.append({"pod": pod, "reason": "Prometheus", "timestamp": ""})
     return res
 
+
 # ---------------------------
 # get namespaces and apply include/exclude regex lists
 # ---------------------------
-def get_namespaces_for_context(context: str, retries: int, oc_timeout_seconds: int,
-                               include_patterns: Optional[List[Pattern]] = None,
-                               exclude_patterns: Optional[List[Pattern]] = None) -> List[str]:
+def get_namespaces_for_context(
+    context: str,
+    retries: int,
+    oc_timeout_seconds: int,
+    include_patterns: Optional[List[Pattern]] = None,
+    exclude_patterns: Optional[List[Pattern]] = None,
+) -> List[str]:
+    """Get namespaces for a context, optionally filtered by include/exclude patterns."""
     subcmd = ["get", "ns", "-o", "json"]
-    rc, out, err = run_oc_subcommand(context, subcmd, retries=retries, oc_timeout_seconds=oc_timeout_seconds)
+    rc, out, err = run_oc_subcommand(
+        context, subcmd, retries=retries, oc_timeout_seconds=oc_timeout_seconds
+    )
     if rc != 0 or not out:
         return []
     try:
         obj = json.loads(out)
-    except Exception:
+    except json.JSONDecodeError as e:
+        logging.warning(f"Failed to parse namespaces JSON: {e}")
         return []
-    all_ns = [it.get("metadata", {}).get("name") for it in obj.get("items", []) if it.get("metadata", {}).get("name")]
+    all_ns = [
+        it.get("metadata", {}).get("name")
+        for it in obj.get("items", [])
+        if it.get("metadata", {}).get("name")
+    ]
     filtered: List[str] = []
     for ns in all_ns:
         include = True
@@ -253,12 +380,19 @@ def get_namespaces_for_context(context: str, retries: int, oc_timeout_seconds: i
         filtered.append(ns)
     return filtered
 
+
 # ---------------------------
 # Save pod artifacts (describe + logs) into per-cluster directory under /tmp/<cluster>/
 # Returns (description_path, log_path)
 # ---------------------------
-def save_pod_artifacts(context: str, cluster: str, namespace: str, pod: str,
-                       retries: int, oc_timeout_seconds: int) -> Tuple[str, str]:
+def save_pod_artifacts(
+    context: str,
+    cluster: str,
+    namespace: str,
+    pod: str,
+    retries: int,
+    oc_timeout_seconds: int,
+) -> Tuple[str, str]:
     """
     Save 'oc describe pod' and 'oc logs pod' (or --previous) into files under /tmp/<cluster>/
     Filenames include namespace, pod name and timestamp to avoid collisions.
@@ -269,8 +403,8 @@ def save_pod_artifacts(context: str, cluster: str, namespace: str, pod: str,
     cluster_dir.mkdir(parents=True, exist_ok=True)
 
     # safe filename parts
-    ns_safe = re.sub(r'[^A-Za-z0-9_.-]', '_', namespace)
-    pod_safe = re.sub(r'[^A-Za-z0-9_.-]', '_', pod)
+    ns_safe = re.sub(r"[^A-Za-z0-9_.-]", "_", namespace)
+    pod_safe = re.sub(r"[^A-Za-z0-9_.-]", "_", pod)
 
     desc_fname = f"{ns_safe}__{pod_safe}__{ts}__desc.txt"
     log_fname = f"{ns_safe}__{pod_safe}__{ts}__log.txt"
@@ -280,9 +414,19 @@ def save_pod_artifacts(context: str, cluster: str, namespace: str, pod: str,
 
     # oc describe pod
     try:
-        rc, out, err = run_oc_subcommand(context, ["-n", namespace, "describe", "pod", pod], retries=retries, oc_timeout_seconds=oc_timeout_seconds)
-        content_desc = out if rc == 0 and out else (err if err else "Failed to fetch pod description")
+        rc, out, err = run_oc_subcommand(
+            context,
+            ["-n", namespace, "describe", "pod", pod],
+            retries=retries,
+            oc_timeout_seconds=oc_timeout_seconds,
+        )
+        content_desc = (
+            out
+            if rc == 0 and out
+            else (err if err else "Failed to fetch pod description")
+        )
     except Exception as e:
+        logging.error(f"Error fetching pod description for {namespace}/{pod}: {e}")
         content_desc = f"Error fetching pod description: {e}"
 
     try:
@@ -291,25 +435,40 @@ def save_pod_artifacts(context: str, cluster: str, namespace: str, pod: str,
         # fallback to best-effort path
         desc_path = cluster_dir / f"{ns_safe}__{pod_safe}__{ts}__desc.failed.txt"
         try:
-            desc_path.write_text(f"Failed to write description: {e}\nOriginal content:\n{content_desc}")
+            desc_path.write_text(
+                f"Failed to write description: {e}\nOriginal content:\n{content_desc}"
+            )
         except Exception:
             pass
 
     # oc logs pod (current)
     log_content = ""
     try:
-        rc2, out2, err2 = run_oc_subcommand(context, ["-n", namespace, "logs", pod], retries=retries, oc_timeout_seconds=oc_timeout_seconds)
+        rc2, out2, err2 = run_oc_subcommand(
+            context,
+            ["-n", namespace, "logs", pod],
+            retries=retries,
+            oc_timeout_seconds=oc_timeout_seconds,
+        )
         if rc2 == 0 and out2:
             log_content = out2
         else:
             # try previous
-            rc3, out3, err3 = run_oc_subcommand(context, ["-n", namespace, "logs", pod, "--previous"], retries=retries, oc_timeout_seconds=oc_timeout_seconds)
+            rc3, out3, err3 = run_oc_subcommand(
+                context,
+                ["-n", namespace, "logs", pod, "--previous"],
+                retries=retries,
+                oc_timeout_seconds=oc_timeout_seconds,
+            )
             if rc3 == 0 and out3:
                 log_content = out3
             else:
                 # if both empty, record the stderr or note
-                log_content = err2 or err3 or "No logs found (both current and previous empty)"
+                log_content = (
+                    err2 or err3 or "No logs found (both current and previous empty)"
+                )
     except Exception as e:
+        logging.error(f"Error fetching logs for {namespace}/{pod}: {e}")
         log_content = f"Error fetching logs: {e}"
 
     try:
@@ -317,38 +476,71 @@ def save_pod_artifacts(context: str, cluster: str, namespace: str, pod: str,
     except Exception as e:
         log_path = cluster_dir / f"{ns_safe}__{pod_safe}__{ts}__log.failed.txt"
         try:
-            log_path.write_text(f"Failed to write logs: {e}\nOriginal logs content:\n{log_content}")
+            log_path.write_text(
+                f"Failed to write logs: {e}\nOriginal logs content:\n{log_content}"
+            )
         except Exception:
             pass
 
     return str(desc_path.resolve()), str(log_path.resolve())
 
+
 # ---------------------------
 # namespace worker (oc-only)
 # ---------------------------
-def namespace_worker_oc(context: str, namespace: str, retries: int, oc_timeout_seconds: int
-                        ) -> Optional[Dict[str, Dict[str, Any]]]:
+def namespace_worker_oc(
+    context: str, namespace: str, retries: int, oc_timeout_seconds: int
+) -> Optional[Dict[str, Dict[str, Any]]]:
     pod_map: Dict[str, Dict[str, Any]] = {}
 
-    oom_events = find_events_by_reason_oc(context, namespace, "OOMKilled", retries=retries, oc_timeout_seconds=oc_timeout_seconds)
-    crash_events = find_events_by_reason_oc(context, namespace, "CrashLoop", retries=retries, oc_timeout_seconds=oc_timeout_seconds)
-    backoff_events = find_events_by_reason_oc(context, namespace, "BackOff", retries=retries, oc_timeout_seconds=oc_timeout_seconds)
-    crash_pods = crashloop_via_pods_oc(context, namespace, retries=retries, oc_timeout_seconds=oc_timeout_seconds)
+    oom_events = find_events_by_reason_oc(
+        context,
+        namespace,
+        "OOMKilled",
+        retries=retries,
+        oc_timeout_seconds=oc_timeout_seconds,
+    )
+    crash_events = find_events_by_reason_oc(
+        context,
+        namespace,
+        "CrashLoop",
+        retries=retries,
+        oc_timeout_seconds=oc_timeout_seconds,
+    )
+    backoff_events = find_events_by_reason_oc(
+        context,
+        namespace,
+        "BackOff",
+        retries=retries,
+        oc_timeout_seconds=oc_timeout_seconds,
+    )
+    crash_pods = crashloop_via_pods_oc(
+        context, namespace, retries=retries, oc_timeout_seconds=oc_timeout_seconds
+    )
 
     for e in oom_events:
         p = e["pod"]
-        pod_map.setdefault(p, {"pod": p, "oom_timestamps": [], "crash_timestamps": [], "sources": set()})
-        pod_map[p]["oom_timestamps"].append(e.get("timestamp",""))
+        pod_map.setdefault(
+            p,
+            {"pod": p, "oom_timestamps": [], "crash_timestamps": [], "sources": set()},
+        )
+        pod_map[p]["oom_timestamps"].append(e.get("timestamp", ""))
         pod_map[p]["sources"].add("events")
     for e in crash_events + backoff_events:
         p = e["pod"]
-        pod_map.setdefault(p, {"pod": p, "oom_timestamps": [], "crash_timestamps": [], "sources": set()})
-        pod_map[p]["crash_timestamps"].append(e.get("timestamp",""))
+        pod_map.setdefault(
+            p,
+            {"pod": p, "oom_timestamps": [], "crash_timestamps": [], "sources": set()},
+        )
+        pod_map[p]["crash_timestamps"].append(e.get("timestamp", ""))
         pod_map[p]["sources"].add("events")
     for e in crash_pods:
         p = e["pod"]
-        pod_map.setdefault(p, {"pod": p, "oom_timestamps": [], "crash_timestamps": [], "sources": set()})
-        pod_map[p]["crash_timestamps"].append(e.get("timestamp",""))
+        pod_map.setdefault(
+            p,
+            {"pod": p, "oom_timestamps": [], "crash_timestamps": [], "sources": set()},
+        )
+        pod_map[p]["crash_timestamps"].append(e.get("timestamp", ""))
         pod_map[p]["sources"].add("oc_get_pods")
 
     if pod_map:
@@ -358,22 +550,30 @@ def namespace_worker_oc(context: str, namespace: str, retries: int, oc_timeout_s
                 "pod": p,
                 "oom_timestamps": sorted(list(set(info.get("oom_timestamps", [])))),
                 "crash_timestamps": sorted(list(set(info.get("crash_timestamps", [])))),
-                "sources": sorted(list(info.get("sources", [])))
+                "sources": sorted(list(info.get("sources", []))),
             }
         return out_ns
     return None
 
+
 # ---------------------------
 # query a single cluster (namespaces in parallel batches)
 # ---------------------------
-def query_context(context: str, retries: int, oc_timeout_seconds: int,
-                  ns_batch_size: int = DEFAULT_NS_BATCH_SIZE, ns_workers: int = DEFAULT_NS_WORKERS,
-                  prom_workers: Optional[int] = None, skip_prometheus: bool = False
-                  ) -> Tuple[str, Dict[str, Any], Optional[str]]:
+def query_context(
+    context: str,
+    retries: int,
+    oc_timeout_seconds: int,
+    ns_batch_size: int = DEFAULT_NS_BATCH_SIZE,
+    ns_workers: int = DEFAULT_NS_WORKERS,
+    prom_workers: Optional[int] = None,
+    skip_prometheus: bool = False,
+) -> Tuple[str, Dict[str, Any], Optional[str]]:
     cluster = short_cluster_name(context)
     print(color(f"\n→ Processing cluster: {cluster}", BLUE))
 
-    ok, msg = check_cluster_connectivity(context, retries=retries, oc_timeout_seconds=oc_timeout_seconds)
+    ok, msg = check_cluster_connectivity(
+        context, retries=retries, oc_timeout_seconds=oc_timeout_seconds
+    )
     if not ok:
         err_msg = f"Cluster {cluster} unreachable or auth/connectivity failure: {msg}"
         print(color(f"  [SKIP] {err_msg}", RED))
@@ -382,9 +582,14 @@ def query_context(context: str, retries: int, oc_timeout_seconds: int,
     if prom_workers is None:
         prom_workers = ns_workers
 
-    global _INCLUDE_PATTERNS, _EXCLUDE_PATTERNS
-    namespaces = get_namespaces_for_context(context, retries=retries, oc_timeout_seconds=oc_timeout_seconds,
-                                           include_patterns=_INCLUDE_PATTERNS, exclude_patterns=_EXCLUDE_PATTERNS)
+    # Access global patterns (set in parse_args)
+    namespaces = get_namespaces_for_context(
+        context,
+        retries=retries,
+        oc_timeout_seconds=oc_timeout_seconds,
+        include_patterns=_INCLUDE_PATTERNS,
+        exclude_patterns=_EXCLUDE_PATTERNS,
+    )
     if not namespaces:
         return cluster, {}, None
 
@@ -393,11 +598,21 @@ def query_context(context: str, retries: int, oc_timeout_seconds: int,
 
     total_ns = len(namespaces)
     for i in range(0, total_ns, ns_batch_size):
-        ns_batch = namespaces[i:i+ns_batch_size]
-        print(color(f"  Namespace batch {i//ns_batch_size + 1}: {len(ns_batch)} namespaces", YELLOW))
+        ns_batch = namespaces[i : i + ns_batch_size]
+        print(
+            color(
+                f"  Namespace batch {i//ns_batch_size + 1}: {len(ns_batch)} namespaces",
+                YELLOW,
+            )
+        )
 
         with ThreadPoolExecutor(max_workers=min(ns_workers, len(ns_batch))) as ex:
-            futures = {ex.submit(namespace_worker_oc, context, ns, retries, oc_timeout_seconds): ns for ns in ns_batch}
+            futures = {
+                ex.submit(
+                    namespace_worker_oc, context, ns, retries, oc_timeout_seconds
+                ): ns
+                for ns in ns_batch
+            }
             for fut in as_completed(futures):
                 ns = futures[fut]
                 try:
@@ -406,32 +621,66 @@ def query_context(context: str, retries: int, oc_timeout_seconds: int,
                         # Save artifacts for each pod found in this namespace
                         out_ns_with_artifacts: Dict[str, Dict[str, Any]] = {}
                         for p, info in res.items():
-                            desc_file, log_file = save_pod_artifacts(context, cluster, ns, p, retries, oc_timeout_seconds)
+                            desc_file, log_file = save_pod_artifacts(
+                                context, cluster, ns, p, retries, oc_timeout_seconds
+                            )
                             info["description_file"] = desc_file
                             info["pod_log_file"] = log_file
                             out_ns_with_artifacts[p] = info
                         cluster_result[ns] = out_ns_with_artifacts
-                        print(color(f"    Namespace {ns}: {len(res)} pod(s) found via oc", YELLOW))
+                        print(
+                            color(
+                                f"    Namespace {ns}: {len(res)} pod(s) found via oc",
+                                YELLOW,
+                            )
+                        )
                     else:
                         namespaces_needing_prom.add(ns)
                 except Exception as e:
                     print(color(f"    Error processing namespace {ns}: {e}", RED))
                     namespaces_needing_prom.add(ns)
 
-    # Prometheus fallback: run for namespaces_needing_prom in batches and parallelized (bounded by prom_workers)
+    # Prometheus fallback: run for namespaces_needing_prom in batches and parallelized
     if not skip_prometheus and namespaces_needing_prom:
-        print(color(f"  Running Prometheus fallback for {len(namespaces_needing_prom)} namespace(s) in batches", BLUE))
+        ns_count = len(namespaces_needing_prom)
+        print(
+            color(
+                f"  Running Prometheus fallback for {ns_count} namespace(s) in batches",
+                BLUE,
+            )
+        )
         prom_list = sorted(list(namespaces_needing_prom))
         for i in range(0, len(prom_list), ns_batch_size):
-            prom_batch = prom_list[i:i+ns_batch_size]
-            print(color(f"    Prom batch {i//ns_batch_size + 1}: {len(prom_batch)} namespaces", YELLOW))
-            with ThreadPoolExecutor(max_workers=min(prom_workers, len(prom_batch))) as pex:
+            prom_batch = prom_list[i : i + ns_batch_size]
+            print(
+                color(
+                    f"    Prom batch {i//ns_batch_size + 1}: {len(prom_batch)} namespaces",
+                    YELLOW,
+                )
+            )
+            with ThreadPoolExecutor(
+                max_workers=min(prom_workers, len(prom_batch))
+            ) as pex:
                 pfutures = {}
                 # schedule oom and crash queries as separate tasks
                 for ns in prom_batch:
-                    f1 = pex.submit(prom_query_from_prometheus_pod, context, ns, PROMQL_OOM.format(namespace=ns), retries, oc_timeout_seconds)
+                    f1 = pex.submit(
+                        prom_query_from_prometheus_pod,
+                        context,
+                        ns,
+                        PROMQL_OOM.format(namespace=ns),
+                        retries,
+                        oc_timeout_seconds,
+                    )
                     pfutures[f1] = (ns, "oom")
-                    f2 = pex.submit(prom_query_from_prometheus_pod, context, ns, PROMQL_CRASH.format(namespace=ns), retries, oc_timeout_seconds)
+                    f2 = pex.submit(
+                        prom_query_from_prometheus_pod,
+                        context,
+                        ns,
+                        PROMQL_CRASH.format(namespace=ns),
+                        retries,
+                        oc_timeout_seconds,
+                    )
                     pfutures[f2] = (ns, "crash")
                 prom_results_per_ns: Dict[str, Dict[str, Any]] = {}
                 for pfut in as_completed(pfutures):
@@ -443,27 +692,46 @@ def query_context(context: str, retries: int, oc_timeout_seconds: int,
                         ns_map = prom_results_per_ns.setdefault(ns, {})
                         for item in res:
                             p = item["pod"]
-                            ns_map.setdefault(p, {"pod": p, "oom_timestamps": [], "crash_timestamps": [], "sources": set()})
+                            ns_map.setdefault(
+                                p,
+                                {
+                                    "pod": p,
+                                    "oom_timestamps": [],
+                                    "crash_timestamps": [],
+                                    "sources": set(),
+                                },
+                            )
                             ns_map[p]["sources"].add("prometheus")
                     except Exception as e:
-                        print(color(f"      Prometheus query failed for ns={ns}: {e}", RED))
+                        print(
+                            color(
+                                f"      Prometheus query failed for ns={ns}: {e}", RED
+                            )
+                        )
                 # after collecting prom batch, attach and save artifacts
                 for ns, ns_map in prom_results_per_ns.items():
                     out_ns: Dict[str, Dict[str, Any]] = {}
                     for p, info in ns_map.items():
                         # save artifacts for prom-found pod as well
-                        desc_file, log_file = save_pod_artifacts(context, cluster, ns, p, retries, oc_timeout_seconds)
+                        desc_file, log_file = save_pod_artifacts(
+                            context, cluster, ns, p, retries, oc_timeout_seconds
+                        )
                         info2 = {
                             "pod": p,
                             "oom_timestamps": [],
                             "crash_timestamps": [],
                             "sources": sorted(list(info.get("sources", []))),
                             "description_file": desc_file,
-                            "pod_log_file": log_file
+                            "pod_log_file": log_file,
                         }
                         out_ns[p] = info2
                     cluster_result[ns] = out_ns
-                    print(color(f"    Prometheus found {len(out_ns)} pod(s) in namespace {ns}", YELLOW))
+                    print(
+                        color(
+                            f"    Prometheus found {len(out_ns)} pod(s) in namespace {ns}",
+                            YELLOW,
+                        )
+                    )
 
     # write per-cluster log
     try:
@@ -474,20 +742,40 @@ def query_context(context: str, retries: int, oc_timeout_seconds: int,
 
     return cluster, cluster_result, None
 
+
 # ---------------------------
 # cluster batch runner
 # ---------------------------
-def run_batches(contexts: List[str], batch_size: int, retries: int, oc_timeout_seconds: int,
-                ns_batch_size: int, ns_workers: int, prom_workers: int, skip_prometheus: bool
-                ) -> Tuple[Dict[str, Any], Dict[str, str]]:
+def run_batches(
+    contexts: List[str],
+    batch_size: int,
+    retries: int,
+    oc_timeout_seconds: int,
+    ns_batch_size: int,
+    ns_workers: int,
+    prom_workers: int,
+    skip_prometheus: bool,
+) -> Tuple[Dict[str, Any], Dict[str, str]]:
     results: Dict[str, Any] = {}
     skipped: Dict[str, str] = {}
     total = len(contexts)
     for i in range(0, total, batch_size):
-        batch = contexts[i:i+batch_size]
+        batch = contexts[i : i + batch_size]
         print(color(f"\n=== Cluster batch {i//batch_size + 1}: {batch} ===", BLUE))
         with ThreadPoolExecutor(max_workers=len(batch)) as ex:
-            futures = {ex.submit(query_context, ctx, retries, oc_timeout_seconds, ns_batch_size, ns_workers, prom_workers, skip_prometheus): ctx for ctx in batch}
+            futures = {
+                ex.submit(
+                    query_context,
+                    ctx,
+                    retries,
+                    oc_timeout_seconds,
+                    ns_batch_size,
+                    ns_workers,
+                    prom_workers,
+                    skip_prometheus,
+                ): ctx
+                for ctx in batch
+            }
             for fut in as_completed(futures):
                 ctx = futures[fut]
                 try:
@@ -504,34 +792,95 @@ def run_batches(contexts: List[str], batch_size: int, retries: int, oc_timeout_s
                     print(color(f"Error processing {cluster_guess}: {e}", RED))
     return results, skipped
 
+
 # ---------------------------
 # exports & pretty print
 # ---------------------------
 def export_results(results: Dict[str, Any], json_path: Path, csv_path: Path) -> None:
-    # JSON structure is already namespace -> pod -> info with description_file and pod_log_file included
-    json_path.write_text(json.dumps(results, indent=2))
-    print(color(f"JSON written → {json_path}", GREEN))
+    """Export results to JSON and CSV files."""
+    # JSON structure: namespace -> pod -> info with description_file and pod_log_file
+    try:
+        json_path.write_text(json.dumps(results, indent=2))
+        print(color(f"JSON written → {json_path}", GREEN))
+    except (IOError, OSError) as e:
+        logging.error(f"Failed to write JSON file {json_path}: {e}")
+        print(color(f"ERROR: Failed to write JSON file: {e}", RED))
 
     # CSV: cluster,namespace,pod,type,timestamps,sources,description_file,pod_log_file
-    with csv_path.open("w", newline="") as f:
-        writer = csv.writer(f)
-        writer.writerow(["cluster", "namespace", "pod", "type", "timestamps", "sources", "description_file", "pod_log_file"])
-        for cluster, ns_map in results.items():
-            for ns, pods in ns_map.items():
-                for pod_name, info in pods.items():
-                    desc = info.get("description_file", "")
-                    plog = info.get("pod_log_file", "")
-                    sources = ";".join(info.get("sources", [])) if info.get("sources") else ""
-                    # OOM rows
-                    if info.get("oom_timestamps"):
-                        writer.writerow([cluster, ns, pod_name, "OOMKilled", ";".join(info.get("oom_timestamps")), sources, desc, plog])
-                    # Crash rows
-                    if info.get("crash_timestamps"):
-                        writer.writerow([cluster, ns, pod_name, "CrashLoopBackOff", ";".join(info.get("crash_timestamps")), sources, desc, plog])
-                    # If neither timestamps but prom-found, write FoundBy row
-                    if not info.get("oom_timestamps") and not info.get("crash_timestamps"):
-                        writer.writerow([cluster, ns, pod_name, "FoundBy", "", sources, desc, plog])
-    print(color(f"CSV written → {csv_path}", GREEN))
+    try:
+        with csv_path.open("w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(
+                [
+                    "cluster",
+                    "namespace",
+                    "pod",
+                    "type",
+                    "timestamps",
+                    "sources",
+                    "description_file",
+                    "pod_log_file",
+                ]
+            )
+            for cluster, ns_map in results.items():
+                for ns, pods in ns_map.items():
+                    for pod_name, info in pods.items():
+                        desc = info.get("description_file", "")
+                        plog = info.get("pod_log_file", "")
+                        sources = (
+                            ";".join(info.get("sources", []))
+                            if info.get("sources")
+                            else ""
+                        )
+                        # OOM rows
+                        if info.get("oom_timestamps"):
+                            writer.writerow(
+                                [
+                                    cluster,
+                                    ns,
+                                    pod_name,
+                                    "OOMKilled",
+                                    ";".join(info.get("oom_timestamps")),
+                                    sources,
+                                    desc,
+                                    plog,
+                                ]
+                            )
+                        # Crash rows
+                        if info.get("crash_timestamps"):
+                            writer.writerow(
+                                [
+                                    cluster,
+                                    ns,
+                                    pod_name,
+                                    "CrashLoopBackOff",
+                                    ";".join(info.get("crash_timestamps")),
+                                    sources,
+                                    desc,
+                                    plog,
+                                ]
+                            )
+                        # If neither timestamps but prom-found, write FoundBy row
+                        if not info.get("oom_timestamps") and not info.get(
+                            "crash_timestamps"
+                        ):
+                            writer.writerow(
+                                [
+                                    cluster,
+                                    ns,
+                                    pod_name,
+                                    "FoundBy",
+                                    "",
+                                    sources,
+                                    desc,
+                                    plog,
+                                ]
+                            )
+        print(color(f"CSV written → {csv_path}", GREEN))
+    except (IOError, OSError) as e:
+        logging.error(f"Failed to write CSV file {csv_path}: {e}")
+        print(color(f"ERROR: Failed to write CSV file: {e}", RED))
+
 
 def pretty_print(results: Dict[str, Any], skipped: Dict[str, str]) -> None:
     for cluster, ns_map in results.items():
@@ -543,7 +892,11 @@ def pretty_print(results: Dict[str, Any], skipped: Dict[str, str]) -> None:
         for ns, pods in ns_map.items():
             print(color(f"  Namespace: {ns}", YELLOW))
             for pod_name, info in pods.items():
-                heading_color = RED if (info.get("oom_timestamps") or info.get("crash_timestamps")) else GREEN
+                heading_color = (
+                    RED
+                    if (info.get("oom_timestamps") or info.get("crash_timestamps"))
+                    else GREEN
+                )
                 print(color(f"    Pod: {pod_name}", heading_color))
                 if info.get("oom_timestamps"):
                     for t in info["oom_timestamps"]:
@@ -552,16 +905,22 @@ def pretty_print(results: Dict[str, Any], skipped: Dict[str, str]) -> None:
                     for t in info["crash_timestamps"]:
                         print(f"      - CrashLoopBackOff event at: {t}")
                 if not info.get("oom_timestamps") and not info.get("crash_timestamps"):
-                    print(f"      - Detected (no timestamps) via sources: {', '.join(info.get('sources', []))}")
+                    sources_str = ", ".join(info.get("sources", []))
+                    print(
+                        f"      - Detected (no timestamps) via sources: {sources_str}"
+                    )
                 # print artifacts paths
                 if info.get("description_file") or info.get("pod_log_file"):
-                    print(f"      - description_file: {info.get('description_file','')}")
-                    print(f"      - pod_log_file: {info.get('pod_log_file','')}")
+                    print(
+                        f"      - description_file: {info.get('description_file', '')}"
+                    )
+                    print(f"      - pod_log_file: {info.get('pod_log_file', '')}")
     if skipped:
         print()
         print(color("Skipped / Unreachable clusters:", RED))
         for c, msg in skipped.items():
             print(color(f"  {c}: {msg}", RED))
+
 
 # ---------------------------
 # global patterns (populated in parse_args)
@@ -569,11 +928,13 @@ def pretty_print(results: Dict[str, Any], skipped: Dict[str, str]) -> None:
 _INCLUDE_PATTERNS: Optional[List[Pattern]] = None
 _EXCLUDE_PATTERNS: Optional[List[Pattern]] = None
 
+
 # ---------------------------
 # argument parsing
 # ---------------------------
 def print_usage_and_exit() -> None:
-    print("""
+    print(
+        """
 Usage:
   oc_get_ooms.py [--current] [--contexts ctxA,ctxB] [--batch N]
                  [--ns-batch-size M] [--ns-workers W] [--prom-workers P]
@@ -586,15 +947,18 @@ Options:
   --batch N                Cluster-level batch size (default 2)
   --ns-batch-size M        Number of namespaces in each namespace batch (default 10)
   --ns-workers W           Thread pool size for oc checks per namespace batch (default 5)
-  --prom-workers P         Thread pool size for Prometheus queries per prom-batch (default = ns-workers)
+  --prom-workers P         Thread pool size for Prometheus queries per prom-batch
+                          (default = ns-workers)
   --skip-prometheus        Do not run Prometheus fallback
   --include-ns regex,...   Comma-separated regex patterns to include (namespace must match any)
   --exclude-ns regex,...   Comma-separated regex patterns to exclude (if match any -> excluded)
   --retries R              Number of retries for oc calls (default 3)
   --timeout S              OC request timeout in seconds used as --request-timeout (default 45)
   --help                   Show this help
-""")
+"""
+    )
     sys.exit(1)
+
 
 def compile_patterns(csv_patterns: Optional[str]) -> Optional[List[Pattern]]:
     if not csv_patterns:
@@ -608,13 +972,14 @@ def compile_patterns(csv_patterns: Optional[str]) -> Optional[List[Pattern]]:
         print(color(f"Invalid regex in patterns: {e}", RED))
         sys.exit(1)
 
+
 def parse_args(argv: List[str]) -> Tuple[List[str], int, int, int, int, int, bool, int]:
     args = list(argv)
     if "--help" in args:
         print_usage_and_exit()
 
     contexts: List[str] = []
-    batch_size = 2
+    batch_size = DEFAULT_BATCH_SIZE
     ns_batch_size = DEFAULT_NS_BATCH_SIZE
     ns_workers = DEFAULT_NS_WORKERS
     prom_workers = None
@@ -625,7 +990,9 @@ def parse_args(argv: List[str]) -> Tuple[List[str], int, int, int, int, int, boo
     exclude_csv = None
 
     if "--current" in args:
-        cur = get_current_context(retries=retries, oc_timeout_seconds=oc_timeout_seconds)
+        cur = get_current_context(
+            retries=retries, oc_timeout_seconds=oc_timeout_seconds
+        )
         if cur:
             contexts = [cur]
     elif "--contexts" in args:
@@ -633,40 +1000,62 @@ def parse_args(argv: List[str]) -> Tuple[List[str], int, int, int, int, int, boo
         if i + 1 >= len(args):
             print(color("ERROR: missing argument for --contexts", RED))
             print_usage_and_exit()
-        contexts = [c.strip() for c in args[i+1].split(",") if c.strip()]
+        contexts = [c.strip() for c in args[i + 1].split(",") if c.strip()]
     else:
-        contexts = get_all_contexts(retries=retries, oc_timeout_seconds=oc_timeout_seconds)
+        contexts = get_all_contexts(
+            retries=retries, oc_timeout_seconds=oc_timeout_seconds
+        )
 
     if "--batch" in args:
         i = args.index("--batch")
+        if i + 1 >= len(args):
+            print(color("ERROR: missing argument for --batch", RED))
+            print_usage_and_exit()
         try:
-            batch_size = int(args[i+1])
-        except Exception:
-            print(color("ERROR: invalid --batch value", RED))
+            batch_size = int(args[i + 1])
+            if batch_size < 1:
+                raise ValueError("batch size must be >= 1")
+        except (ValueError, IndexError) as e:
+            print(color(f"ERROR: invalid --batch value: {e}", RED))
             print_usage_and_exit()
 
     if "--ns-batch-size" in args:
         i = args.index("--ns-batch-size")
+        if i + 1 >= len(args):
+            print(color("ERROR: missing argument for --ns-batch-size", RED))
+            print_usage_and_exit()
         try:
-            ns_batch_size = int(args[i+1])
-        except Exception:
-            print(color("ERROR: invalid --ns-batch-size value", RED))
+            ns_batch_size = int(args[i + 1])
+            if ns_batch_size < 1:
+                raise ValueError("ns-batch-size must be >= 1")
+        except (ValueError, IndexError) as e:
+            print(color(f"ERROR: invalid --ns-batch-size value: {e}", RED))
             print_usage_and_exit()
 
     if "--ns-workers" in args:
         i = args.index("--ns-workers")
+        if i + 1 >= len(args):
+            print(color("ERROR: missing argument for --ns-workers", RED))
+            print_usage_and_exit()
         try:
-            ns_workers = int(args[i+1])
-        except Exception:
-            print(color("ERROR: invalid --ns-workers value", RED))
+            ns_workers = int(args[i + 1])
+            if ns_workers < 1:
+                raise ValueError("ns-workers must be >= 1")
+        except (ValueError, IndexError) as e:
+            print(color(f"ERROR: invalid --ns-workers value: {e}", RED))
             print_usage_and_exit()
 
     if "--prom-workers" in args:
         i = args.index("--prom-workers")
+        if i + 1 >= len(args):
+            print(color("ERROR: missing argument for --prom-workers", RED))
+            print_usage_and_exit()
         try:
-            prom_workers = int(args[i+1])
-        except Exception:
-            print(color("ERROR: invalid --prom-workers value", RED))
+            prom_workers = int(args[i + 1])
+            if prom_workers < 1:
+                raise ValueError("prom-workers must be >= 1")
+        except (ValueError, IndexError) as e:
+            print(color(f"ERROR: invalid --prom-workers value: {e}", RED))
             print_usage_and_exit()
 
     if "--skip-prometheus" in args:
@@ -674,26 +1063,36 @@ def parse_args(argv: List[str]) -> Tuple[List[str], int, int, int, int, int, boo
 
     if "--include-ns" in args:
         i = args.index("--include-ns")
-        include_csv = args[i+1] if i+1 < len(args) else None
+        include_csv = args[i + 1] if i + 1 < len(args) else None
 
     if "--exclude-ns" in args:
         i = args.index("--exclude-ns")
-        exclude_csv = args[i+1] if i+1 < len(args) else None
+        exclude_csv = args[i + 1] if i + 1 < len(args) else None
 
     if "--retries" in args:
         i = args.index("--retries")
+        if i + 1 >= len(args):
+            print(color("ERROR: missing argument for --retries", RED))
+            print_usage_and_exit()
         try:
-            retries = int(args[i+1])
-        except Exception:
-            print(color("ERROR: invalid --retries value", RED))
+            retries = int(args[i + 1])
+            if retries < 1:
+                raise ValueError("retries must be >= 1")
+        except (ValueError, IndexError) as e:
+            print(color(f"ERROR: invalid --retries value: {e}", RED))
             print_usage_and_exit()
 
     if "--timeout" in args:
         i = args.index("--timeout")
+        if i + 1 >= len(args):
+            print(color("ERROR: missing argument for --timeout", RED))
+            print_usage_and_exit()
         try:
-            oc_timeout_seconds = int(args[i+1])
-        except Exception:
-            print(color("ERROR: invalid --timeout value", RED))
+            oc_timeout_seconds = int(args[i + 1])
+            if oc_timeout_seconds < 1:
+                raise ValueError("timeout must be >= 1")
+        except (ValueError, IndexError) as e:
+            print(color(f"ERROR: invalid --timeout value: {e}", RED))
             print_usage_and_exit()
 
     global _INCLUDE_PATTERNS, _EXCLUDE_PATTERNS
@@ -703,27 +1102,84 @@ def parse_args(argv: List[str]) -> Tuple[List[str], int, int, int, int, int, boo
     if prom_workers is None:
         prom_workers = ns_workers
 
-    return contexts, batch_size, ns_batch_size, ns_workers, prom_workers, skip_prometheus, retries, oc_timeout_seconds
+    return (
+        contexts,
+        batch_size,
+        ns_batch_size,
+        ns_workers,
+        prom_workers,
+        skip_prometheus,
+        retries,
+        oc_timeout_seconds,
+    )
+
 
 # ---------------------------
 # main
 # ---------------------------
 def main() -> None:
-    contexts, batch_size, ns_batch_size, ns_workers, prom_workers, skip_prometheus, retries, oc_timeout_seconds = parse_args(sys.argv[1:])
+    """Main entry point for the OOM/CrashLoopBackOff detector."""
+    # Configure logging (quiet by default, can be enhanced with --verbose flag)
+    logging.basicConfig(
+        level=logging.WARNING,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+
+    (
+        contexts,
+        batch_size,
+        ns_batch_size,
+        ns_workers,
+        prom_workers,
+        skip_prometheus,
+        retries,
+        oc_timeout_seconds,
+    ) = parse_args(sys.argv[1:])
 
     if not contexts:
         print(color("No contexts discovered. Exiting.", RED))
         sys.exit(1)
 
     print(color(f"Using contexts: {contexts}", BLUE))
-    print(color(f"Cluster-batch: {batch_size}  NS-batch-size: {ns_batch_size}  NS-workers: {ns_workers}  Prom-workers: {prom_workers}", BLUE))
-    print(color(f"Retries: {retries}  OC timeout(s): {oc_timeout_seconds}s  Skip-prometheus: {skip_prometheus}", BLUE))
+    print(
+        color(
+            f"Cluster-batch: {batch_size}  NS-batch-size: {ns_batch_size}  "
+            f"NS-workers: {ns_workers}  Prom-workers: {prom_workers}",
+            BLUE,
+        )
+    )
+    print(
+        color(
+            f"Retries: {retries}  OC timeout(s): {oc_timeout_seconds}s  "
+            f"Skip-prometheus: {skip_prometheus}",
+            BLUE,
+        )
+    )
     if _INCLUDE_PATTERNS:
-        print(color(f"Include namespace patterns: {[p.pattern for p in _INCLUDE_PATTERNS]}", BLUE))
+        print(
+            color(
+                f"Include namespace patterns: {[p.pattern for p in _INCLUDE_PATTERNS]}",
+                BLUE,
+            )
+        )
     if _EXCLUDE_PATTERNS:
-        print(color(f"Exclude namespace patterns: {[p.pattern for p in _EXCLUDE_PATTERNS]}", BLUE))
+        print(
+            color(
+                f"Exclude namespace patterns: {[p.pattern for p in _EXCLUDE_PATTERNS]}",
+                BLUE,
+            )
+        )
 
-    results, skipped = run_batches(contexts, batch_size, retries, oc_timeout_seconds, ns_batch_size, ns_workers, prom_workers, skip_prometheus)
+    results, skipped = run_batches(
+        contexts,
+        batch_size,
+        retries,
+        oc_timeout_seconds,
+        ns_batch_size,
+        ns_workers,
+        prom_workers,
+        skip_prometheus,
+    )
 
     json_path = Path("oom_results.json")
     csv_path = Path("oom_results.csv")
@@ -732,10 +1188,20 @@ def main() -> None:
     pretty_print(results, skipped)
 
     if skipped:
-        print(color("\nSome clusters were skipped due to connectivity errors (see messages above).", YELLOW))
+        print(
+            color(
+                "\nSome clusters were skipped due to connectivity errors (see messages above).",
+                YELLOW,
+            )
+        )
 
-    print(color("\nPer-cluster logs written to /tmp/<cluster>/ (if any findings were found)", GREEN))
+    print(
+        color(
+            "\nPer-cluster logs written to /tmp/<cluster>/ (if any findings were found)",
+            GREEN,
+        )
+    )
+
 
 if __name__ == "__main__":
     main()
-

--- a/oomkill-and-crashloopbackoff-detector/oc_get_ooms.py
+++ b/oomkill-and-crashloopbackoff-detector/oc_get_ooms.py
@@ -1,0 +1,741 @@
+#!/usr/bin/env python3
+"""
+oc_get_ooms.py
+
+Detect OOMKilled and CrashLoopBackOff pods across multiple OpenShift/Kubernetes contexts,
+parallelized at cluster and namespace levels, with Prometheus fallback and artifact collection.
+
+New in this version:
+- When a pod is detected as OOMKilled or CrashLoopBackOff, save:
+    - `oc describe pod <pod>` output
+    - `oc logs <pod>` (or `oc logs --previous <pod>` if no current logs)
+  into per-cluster directories under /tmp/<cluster>/
+  Filenames include namespace, pod name, and timestamp to avoid collisions.
+- CSV and JSON now include the absolute paths to the description and pod log files:
+    description_file, pod_log_file
+
+All previously requested features retained:
+- cluster batching, namespace batching, Prometheus fallback (parallelized by namespace batches),
+  --skip-prometheus flag, include/exclude regex, retries, timeouts, colorized output, etc.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import json
+import csv
+import re
+import sys
+import time
+from datetime import datetime
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import List, Dict, Any, Tuple, Optional, Set, Pattern
+
+# ---------------------------
+# Color output
+# ---------------------------
+RED    = "\033[1;31m"
+GREEN  = "\033[1;32m"
+YELLOW = "\033[1;33m"
+BLUE   = "\033[1;34m"
+RESET  = "\033[0m"
+
+def color(text: str, c: str) -> str:
+    return f"{c}{text}{RESET}"
+
+# ---------------------------
+# Time windows (kept for context; not used directly for artifact collection)
+# ---------------------------
+TIME_WINDOWS = {
+    "last_1h": 1,
+    "last_3h": 3,
+    "last_6h": 6,
+    "last_24h": 24,
+    "last_48h": 48,
+    "last_3d": 72,
+    "last_5d": 120,
+    "last_7d": 168,
+}
+
+PROMQL_OOM = 'kube_pod_container_status_last_terminated_reason{{reason="OOMKilled",namespace="{namespace}"}}'
+PROMQL_CRASH = 'kube_pod_container_status_waiting_reason{{reason="CrashLoopBackOff",namespace="{namespace}"}}'
+
+# ---------------------------
+# Defaults
+# ---------------------------
+DEFAULT_RETRIES = 3
+DEFAULT_OC_TIMEOUT = 45  # seconds
+RETRY_DELAY_SECONDS = 3
+DEFAULT_NS_BATCH_SIZE = 10
+DEFAULT_NS_WORKERS = 5
+
+# ---------------------------
+# Command runner with retries
+# ---------------------------
+def run_cmd_with_retries(cmd: List[str], retries: int = DEFAULT_RETRIES, timeout: Optional[int] = None
+                         ) -> Tuple[int, str, str]:
+    attempt = 0
+    last_err = ""
+    while attempt < max(1, retries):
+        attempt += 1
+        try:
+            completed = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+            stdout = (completed.stdout or "").strip()
+            stderr = (completed.stderr or "").strip()
+            return completed.returncode, stdout, stderr
+        except subprocess.TimeoutExpired:
+            last_err = f"TimeoutExpired after {timeout}s"
+            time.sleep(RETRY_DELAY_SECONDS * attempt)
+        except Exception as e:
+            last_err = str(e)
+            time.sleep(RETRY_DELAY_SECONDS * attempt)
+    return 1, "", last_err
+
+def run_shell_cmd_with_retries(cmd: str, retries: int = DEFAULT_RETRIES, timeout: Optional[int] = None
+                               ) -> Tuple[int, str, str]:
+    return run_cmd_with_retries(["/bin/sh", "-c", cmd], retries=retries, timeout=timeout)
+
+# ---------------------------
+# oc helpers
+# ---------------------------
+def oc_cmd_parts(context: str, oc_timeout_seconds: int, subcommand: List[str]) -> List[str]:
+    parts = ["oc", f"--request-timeout={oc_timeout_seconds}s"]
+    if context:
+        parts += ["--context", context]
+    parts += subcommand
+    return parts
+
+def run_oc_subcommand(context: str, subcommand: List[str], retries: int, oc_timeout_seconds: int
+                     ) -> Tuple[int, str, str]:
+    cmd = oc_cmd_parts(context, oc_timeout_seconds, subcommand)
+    return run_cmd_with_retries(cmd, retries=retries, timeout=oc_timeout_seconds + 5)
+
+# ---------------------------
+# context utilities
+# ---------------------------
+def get_all_contexts(retries: int, oc_timeout_seconds: int) -> List[str]:
+    rc, out, err = run_shell_cmd_with_retries("oc config get-contexts -o name", retries=retries, timeout=oc_timeout_seconds + 5)
+    if rc != 0 or not out:
+        return []
+    return [line.strip() for line in out.splitlines() if line.strip()]
+
+def get_current_context(retries: int, oc_timeout_seconds: int) -> str:
+    rc, out, err = run_shell_cmd_with_retries("oc config current-context", retries=retries, timeout=oc_timeout_seconds + 5)
+    return out.strip() if rc == 0 else ""
+
+def short_cluster_name(full_ctx: str) -> str:
+    m = re.search(r"api-([^-]+-[^-]+-[^-]+)", full_ctx)
+    if m:
+        return m.group(1)
+    if '/' in full_ctx:
+        return full_ctx.split('/')[-1]
+    return full_ctx.replace('/', '_').replace(':', '_')
+
+# ---------------------------
+# timestamp utilities
+# ---------------------------
+def parse_timestamp_to_iso(ts: str) -> str:
+    if not ts:
+        return ""
+    try:
+        base = ts.split(".")[0].rstrip("Z")
+        dt = datetime.strptime(base, "%Y-%m-%dT%H:%M:%S")
+        return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+    except Exception:
+        return ts
+
+def now_ts_for_filename() -> str:
+    return datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+
+# ---------------------------
+# connectivity
+# ---------------------------
+def check_cluster_connectivity(context: str, retries: int, oc_timeout_seconds: int) -> Tuple[bool, str]:
+    rc, out, err = run_oc_subcommand(context, ["whoami"], retries=retries, oc_timeout_seconds=oc_timeout_seconds)
+    if rc == 0:
+        return True, ""
+    return False, err or out or "unknown error"
+
+# ---------------------------
+# oc-only namespace workers (no Prometheus here)
+# ---------------------------
+def find_events_by_reason_oc(context: str, namespace: str, reason_substring: str,
+                             retries: int, oc_timeout_seconds: int) -> List[Dict[str, str]]:
+    subcmd = ["-n", namespace, "get", "events", "--ignore-not-found", "-o", "json"]
+    rc, out, err = run_oc_subcommand(context, subcmd, retries=retries, oc_timeout_seconds=oc_timeout_seconds)
+    if rc != 0 or not out:
+        return []
+    try:
+        obj = json.loads(out)
+    except Exception:
+        return []
+    res: List[Dict[str, str]] = []
+    for ev in obj.get("items", []):
+        reason = ev.get("reason", "")
+        if reason_substring.lower() not in reason.lower():
+            continue
+        pod = ev.get("involvedObject", {}).get("name")
+        ts = ev.get("eventTime") or ev.get("lastTimestamp") or ev.get("firstTimestamp")
+        if pod and ts:
+            res.append({"pod": pod, "reason": reason, "timestamp": parse_timestamp_to_iso(ts)})
+    return res
+
+def crashloop_via_pods_oc(context: str, namespace: str, retries: int, oc_timeout_seconds: int) -> List[Dict[str, str]]:
+    subcmd = ["-n", namespace, "get", "pods", "-o", "json", "--ignore-not-found"]
+    rc, out, err = run_oc_subcommand(context, subcmd, retries=retries, oc_timeout_seconds=oc_timeout_seconds)
+    if rc != 0 or not out:
+        return []
+    try:
+        obj = json.loads(out)
+    except Exception:
+        return []
+    res: List[Dict[str, str]] = []
+    for item in obj.get("items", []):
+        pod_name = item.get("metadata", {}).get("name")
+        statuses = item.get("status", {}).get("containerStatuses", []) or []
+        for cs in statuses:
+            waiting = cs.get("state", {}).get("waiting")
+            if waiting and waiting.get("reason") == "CrashLoopBackOff":
+                res.append({"pod": pod_name, "reason": "CrashLoopBackOff", "timestamp": ""})
+    return res
+
+# ---------------------------
+# Prometheus fallback (can be parallelized in batches)
+# ---------------------------
+def prom_query_from_prometheus_pod(context: str, namespace: str, promql: str,
+                                   retries: int, oc_timeout_seconds: int) -> List[Dict[str, str]]:
+    find_cmd = f'oc --request-timeout={oc_timeout_seconds}s --context="{context}" -n openshift-monitoring get pod -l app=prometheus -o name | head -1'
+    rc, pod_name, err = run_shell_cmd_with_retries(find_cmd, retries=retries, timeout=oc_timeout_seconds + 5)
+    if rc != 0 or not pod_name:
+        return []
+    query_encoded = promql.replace('"', '\\"')
+    exec_cmd = f'oc --request-timeout={oc_timeout_seconds}s --context="{context}" -n openshift-monitoring exec {pod_name} -- curl -s -G http://localhost:9090/api/v1/query --data-urlencode "query={query_encoded}"'
+    rc2, out2, err2 = run_shell_cmd_with_retries(exec_cmd, retries=retries, timeout=oc_timeout_seconds + 10)
+    if rc2 != 0 or not out2:
+        return []
+    try:
+        resp = json.loads(out2)
+    except Exception:
+        return []
+    res: List[Dict[str, str]] = []
+    for r in resp.get("data", {}).get("result", []):
+        metric = r.get("metric", {})
+        pod = metric.get("pod") or metric.get("instance") or metric.get("container")
+        if pod:
+            res.append({"pod": pod, "reason": "Prometheus", "timestamp": ""})
+    return res
+
+# ---------------------------
+# get namespaces and apply include/exclude regex lists
+# ---------------------------
+def get_namespaces_for_context(context: str, retries: int, oc_timeout_seconds: int,
+                               include_patterns: Optional[List[Pattern]] = None,
+                               exclude_patterns: Optional[List[Pattern]] = None) -> List[str]:
+    subcmd = ["get", "ns", "-o", "json"]
+    rc, out, err = run_oc_subcommand(context, subcmd, retries=retries, oc_timeout_seconds=oc_timeout_seconds)
+    if rc != 0 or not out:
+        return []
+    try:
+        obj = json.loads(out)
+    except Exception:
+        return []
+    all_ns = [it.get("metadata", {}).get("name") for it in obj.get("items", []) if it.get("metadata", {}).get("name")]
+    filtered: List[str] = []
+    for ns in all_ns:
+        include = True
+        if include_patterns:
+            include = any(p.search(ns) for p in include_patterns)
+        if not include:
+            continue
+        if exclude_patterns and any(p.search(ns) for p in exclude_patterns):
+            continue
+        filtered.append(ns)
+    return filtered
+
+# ---------------------------
+# Save pod artifacts (describe + logs) into per-cluster directory under /tmp/<cluster>/
+# Returns (description_path, log_path)
+# ---------------------------
+def save_pod_artifacts(context: str, cluster: str, namespace: str, pod: str,
+                       retries: int, oc_timeout_seconds: int) -> Tuple[str, str]:
+    """
+    Save 'oc describe pod' and 'oc logs pod' (or --previous) into files under /tmp/<cluster>/
+    Filenames include namespace, pod name and timestamp to avoid collisions.
+    Returns absolute file paths (description_file, pod_log_file)
+    """
+    ts = now_ts_for_filename()
+    cluster_dir = Path("/tmp") / cluster
+    cluster_dir.mkdir(parents=True, exist_ok=True)
+
+    # safe filename parts
+    ns_safe = re.sub(r'[^A-Za-z0-9_.-]', '_', namespace)
+    pod_safe = re.sub(r'[^A-Za-z0-9_.-]', '_', pod)
+
+    desc_fname = f"{ns_safe}__{pod_safe}__{ts}__desc.txt"
+    log_fname = f"{ns_safe}__{pod_safe}__{ts}__log.txt"
+
+    desc_path = cluster_dir / desc_fname
+    log_path = cluster_dir / log_fname
+
+    # oc describe pod
+    try:
+        rc, out, err = run_oc_subcommand(context, ["-n", namespace, "describe", "pod", pod], retries=retries, oc_timeout_seconds=oc_timeout_seconds)
+        content_desc = out if rc == 0 and out else (err if err else "Failed to fetch pod description")
+    except Exception as e:
+        content_desc = f"Error fetching pod description: {e}"
+
+    try:
+        desc_path.write_text(content_desc)
+    except Exception as e:
+        # fallback to best-effort path
+        desc_path = cluster_dir / f"{ns_safe}__{pod_safe}__{ts}__desc.failed.txt"
+        try:
+            desc_path.write_text(f"Failed to write description: {e}\nOriginal content:\n{content_desc}")
+        except Exception:
+            pass
+
+    # oc logs pod (current)
+    log_content = ""
+    try:
+        rc2, out2, err2 = run_oc_subcommand(context, ["-n", namespace, "logs", pod], retries=retries, oc_timeout_seconds=oc_timeout_seconds)
+        if rc2 == 0 and out2:
+            log_content = out2
+        else:
+            # try previous
+            rc3, out3, err3 = run_oc_subcommand(context, ["-n", namespace, "logs", pod, "--previous"], retries=retries, oc_timeout_seconds=oc_timeout_seconds)
+            if rc3 == 0 and out3:
+                log_content = out3
+            else:
+                # if both empty, record the stderr or note
+                log_content = err2 or err3 or "No logs found (both current and previous empty)"
+    except Exception as e:
+        log_content = f"Error fetching logs: {e}"
+
+    try:
+        log_path.write_text(log_content)
+    except Exception as e:
+        log_path = cluster_dir / f"{ns_safe}__{pod_safe}__{ts}__log.failed.txt"
+        try:
+            log_path.write_text(f"Failed to write logs: {e}\nOriginal logs content:\n{log_content}")
+        except Exception:
+            pass
+
+    return str(desc_path.resolve()), str(log_path.resolve())
+
+# ---------------------------
+# namespace worker (oc-only)
+# ---------------------------
+def namespace_worker_oc(context: str, namespace: str, retries: int, oc_timeout_seconds: int
+                        ) -> Optional[Dict[str, Dict[str, Any]]]:
+    pod_map: Dict[str, Dict[str, Any]] = {}
+
+    oom_events = find_events_by_reason_oc(context, namespace, "OOMKilled", retries=retries, oc_timeout_seconds=oc_timeout_seconds)
+    crash_events = find_events_by_reason_oc(context, namespace, "CrashLoop", retries=retries, oc_timeout_seconds=oc_timeout_seconds)
+    backoff_events = find_events_by_reason_oc(context, namespace, "BackOff", retries=retries, oc_timeout_seconds=oc_timeout_seconds)
+    crash_pods = crashloop_via_pods_oc(context, namespace, retries=retries, oc_timeout_seconds=oc_timeout_seconds)
+
+    for e in oom_events:
+        p = e["pod"]
+        pod_map.setdefault(p, {"pod": p, "oom_timestamps": [], "crash_timestamps": [], "sources": set()})
+        pod_map[p]["oom_timestamps"].append(e.get("timestamp",""))
+        pod_map[p]["sources"].add("events")
+    for e in crash_events + backoff_events:
+        p = e["pod"]
+        pod_map.setdefault(p, {"pod": p, "oom_timestamps": [], "crash_timestamps": [], "sources": set()})
+        pod_map[p]["crash_timestamps"].append(e.get("timestamp",""))
+        pod_map[p]["sources"].add("events")
+    for e in crash_pods:
+        p = e["pod"]
+        pod_map.setdefault(p, {"pod": p, "oom_timestamps": [], "crash_timestamps": [], "sources": set()})
+        pod_map[p]["crash_timestamps"].append(e.get("timestamp",""))
+        pod_map[p]["sources"].add("oc_get_pods")
+
+    if pod_map:
+        out_ns: Dict[str, Dict[str, Any]] = {}
+        for p, info in pod_map.items():
+            out_ns[p] = {
+                "pod": p,
+                "oom_timestamps": sorted(list(set(info.get("oom_timestamps", [])))),
+                "crash_timestamps": sorted(list(set(info.get("crash_timestamps", [])))),
+                "sources": sorted(list(info.get("sources", [])))
+            }
+        return out_ns
+    return None
+
+# ---------------------------
+# query a single cluster (namespaces in parallel batches)
+# ---------------------------
+def query_context(context: str, retries: int, oc_timeout_seconds: int,
+                  ns_batch_size: int = DEFAULT_NS_BATCH_SIZE, ns_workers: int = DEFAULT_NS_WORKERS,
+                  prom_workers: Optional[int] = None, skip_prometheus: bool = False
+                  ) -> Tuple[str, Dict[str, Any], Optional[str]]:
+    cluster = short_cluster_name(context)
+    print(color(f"\n→ Processing cluster: {cluster}", BLUE))
+
+    ok, msg = check_cluster_connectivity(context, retries=retries, oc_timeout_seconds=oc_timeout_seconds)
+    if not ok:
+        err_msg = f"Cluster {cluster} unreachable or auth/connectivity failure: {msg}"
+        print(color(f"  [SKIP] {err_msg}", RED))
+        return cluster, {}, err_msg
+
+    if prom_workers is None:
+        prom_workers = ns_workers
+
+    global _INCLUDE_PATTERNS, _EXCLUDE_PATTERNS
+    namespaces = get_namespaces_for_context(context, retries=retries, oc_timeout_seconds=oc_timeout_seconds,
+                                           include_patterns=_INCLUDE_PATTERNS, exclude_patterns=_EXCLUDE_PATTERNS)
+    if not namespaces:
+        return cluster, {}, None
+
+    cluster_result: Dict[str, Any] = {}
+    namespaces_needing_prom: Set[str] = set()
+
+    total_ns = len(namespaces)
+    for i in range(0, total_ns, ns_batch_size):
+        ns_batch = namespaces[i:i+ns_batch_size]
+        print(color(f"  Namespace batch {i//ns_batch_size + 1}: {len(ns_batch)} namespaces", YELLOW))
+
+        with ThreadPoolExecutor(max_workers=min(ns_workers, len(ns_batch))) as ex:
+            futures = {ex.submit(namespace_worker_oc, context, ns, retries, oc_timeout_seconds): ns for ns in ns_batch}
+            for fut in as_completed(futures):
+                ns = futures[fut]
+                try:
+                    res = fut.result()
+                    if res:
+                        # Save artifacts for each pod found in this namespace
+                        out_ns_with_artifacts: Dict[str, Dict[str, Any]] = {}
+                        for p, info in res.items():
+                            desc_file, log_file = save_pod_artifacts(context, cluster, ns, p, retries, oc_timeout_seconds)
+                            info["description_file"] = desc_file
+                            info["pod_log_file"] = log_file
+                            out_ns_with_artifacts[p] = info
+                        cluster_result[ns] = out_ns_with_artifacts
+                        print(color(f"    Namespace {ns}: {len(res)} pod(s) found via oc", YELLOW))
+                    else:
+                        namespaces_needing_prom.add(ns)
+                except Exception as e:
+                    print(color(f"    Error processing namespace {ns}: {e}", RED))
+                    namespaces_needing_prom.add(ns)
+
+    # Prometheus fallback: run for namespaces_needing_prom in batches and parallelized (bounded by prom_workers)
+    if not skip_prometheus and namespaces_needing_prom:
+        print(color(f"  Running Prometheus fallback for {len(namespaces_needing_prom)} namespace(s) in batches", BLUE))
+        prom_list = sorted(list(namespaces_needing_prom))
+        for i in range(0, len(prom_list), ns_batch_size):
+            prom_batch = prom_list[i:i+ns_batch_size]
+            print(color(f"    Prom batch {i//ns_batch_size + 1}: {len(prom_batch)} namespaces", YELLOW))
+            with ThreadPoolExecutor(max_workers=min(prom_workers, len(prom_batch))) as pex:
+                pfutures = {}
+                # schedule oom and crash queries as separate tasks
+                for ns in prom_batch:
+                    f1 = pex.submit(prom_query_from_prometheus_pod, context, ns, PROMQL_OOM.format(namespace=ns), retries, oc_timeout_seconds)
+                    pfutures[f1] = (ns, "oom")
+                    f2 = pex.submit(prom_query_from_prometheus_pod, context, ns, PROMQL_CRASH.format(namespace=ns), retries, oc_timeout_seconds)
+                    pfutures[f2] = (ns, "crash")
+                prom_results_per_ns: Dict[str, Dict[str, Any]] = {}
+                for pfut in as_completed(pfutures):
+                    ns, typ = pfutures[pfut]
+                    try:
+                        res = pfut.result()
+                        if not res:
+                            continue
+                        ns_map = prom_results_per_ns.setdefault(ns, {})
+                        for item in res:
+                            p = item["pod"]
+                            ns_map.setdefault(p, {"pod": p, "oom_timestamps": [], "crash_timestamps": [], "sources": set()})
+                            ns_map[p]["sources"].add("prometheus")
+                    except Exception as e:
+                        print(color(f"      Prometheus query failed for ns={ns}: {e}", RED))
+                # after collecting prom batch, attach and save artifacts
+                for ns, ns_map in prom_results_per_ns.items():
+                    out_ns: Dict[str, Dict[str, Any]] = {}
+                    for p, info in ns_map.items():
+                        # save artifacts for prom-found pod as well
+                        desc_file, log_file = save_pod_artifacts(context, cluster, ns, p, retries, oc_timeout_seconds)
+                        info2 = {
+                            "pod": p,
+                            "oom_timestamps": [],
+                            "crash_timestamps": [],
+                            "sources": sorted(list(info.get("sources", []))),
+                            "description_file": desc_file,
+                            "pod_log_file": log_file
+                        }
+                        out_ns[p] = info2
+                    cluster_result[ns] = out_ns
+                    print(color(f"    Prometheus found {len(out_ns)} pod(s) in namespace {ns}", YELLOW))
+
+    # write per-cluster log
+    try:
+        outfile = Path("/tmp") / f"{cluster}.log"
+        outfile.write_text(json.dumps(cluster_result, indent=2))
+    except Exception:
+        pass
+
+    return cluster, cluster_result, None
+
+# ---------------------------
+# cluster batch runner
+# ---------------------------
+def run_batches(contexts: List[str], batch_size: int, retries: int, oc_timeout_seconds: int,
+                ns_batch_size: int, ns_workers: int, prom_workers: int, skip_prometheus: bool
+                ) -> Tuple[Dict[str, Any], Dict[str, str]]:
+    results: Dict[str, Any] = {}
+    skipped: Dict[str, str] = {}
+    total = len(contexts)
+    for i in range(0, total, batch_size):
+        batch = contexts[i:i+batch_size]
+        print(color(f"\n=== Cluster batch {i//batch_size + 1}: {batch} ===", BLUE))
+        with ThreadPoolExecutor(max_workers=len(batch)) as ex:
+            futures = {ex.submit(query_context, ctx, retries, oc_timeout_seconds, ns_batch_size, ns_workers, prom_workers, skip_prometheus): ctx for ctx in batch}
+            for fut in as_completed(futures):
+                ctx = futures[fut]
+                try:
+                    cluster, data, err = fut.result()
+                    if err:
+                        skipped[cluster] = err
+                        print(color(f"Skipped cluster {cluster}: {err}", RED))
+                    else:
+                        results[cluster] = data
+                        print(color(f"Completed cluster {cluster}", GREEN))
+                except Exception as e:
+                    cluster_guess = short_cluster_name(ctx)
+                    skipped[cluster_guess] = str(e)
+                    print(color(f"Error processing {cluster_guess}: {e}", RED))
+    return results, skipped
+
+# ---------------------------
+# exports & pretty print
+# ---------------------------
+def export_results(results: Dict[str, Any], json_path: Path, csv_path: Path) -> None:
+    # JSON structure is already namespace -> pod -> info with description_file and pod_log_file included
+    json_path.write_text(json.dumps(results, indent=2))
+    print(color(f"JSON written → {json_path}", GREEN))
+
+    # CSV: cluster,namespace,pod,type,timestamps,sources,description_file,pod_log_file
+    with csv_path.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["cluster", "namespace", "pod", "type", "timestamps", "sources", "description_file", "pod_log_file"])
+        for cluster, ns_map in results.items():
+            for ns, pods in ns_map.items():
+                for pod_name, info in pods.items():
+                    desc = info.get("description_file", "")
+                    plog = info.get("pod_log_file", "")
+                    sources = ";".join(info.get("sources", [])) if info.get("sources") else ""
+                    # OOM rows
+                    if info.get("oom_timestamps"):
+                        writer.writerow([cluster, ns, pod_name, "OOMKilled", ";".join(info.get("oom_timestamps")), sources, desc, plog])
+                    # Crash rows
+                    if info.get("crash_timestamps"):
+                        writer.writerow([cluster, ns, pod_name, "CrashLoopBackOff", ";".join(info.get("crash_timestamps")), sources, desc, plog])
+                    # If neither timestamps but prom-found, write FoundBy row
+                    if not info.get("oom_timestamps") and not info.get("crash_timestamps"):
+                        writer.writerow([cluster, ns, pod_name, "FoundBy", "", sources, desc, plog])
+    print(color(f"CSV written → {csv_path}", GREEN))
+
+def pretty_print(results: Dict[str, Any], skipped: Dict[str, str]) -> None:
+    for cluster, ns_map in results.items():
+        print()
+        print(color(f"Cluster: {cluster}", BLUE))
+        if not ns_map:
+            print(color("  (no namespaces with OOM/CrashLoopBackOff found)", GREEN))
+            continue
+        for ns, pods in ns_map.items():
+            print(color(f"  Namespace: {ns}", YELLOW))
+            for pod_name, info in pods.items():
+                heading_color = RED if (info.get("oom_timestamps") or info.get("crash_timestamps")) else GREEN
+                print(color(f"    Pod: {pod_name}", heading_color))
+                if info.get("oom_timestamps"):
+                    for t in info["oom_timestamps"]:
+                        print(f"      - OOMKilled at: {t}")
+                if info.get("crash_timestamps"):
+                    for t in info["crash_timestamps"]:
+                        print(f"      - CrashLoopBackOff event at: {t}")
+                if not info.get("oom_timestamps") and not info.get("crash_timestamps"):
+                    print(f"      - Detected (no timestamps) via sources: {', '.join(info.get('sources', []))}")
+                # print artifacts paths
+                if info.get("description_file") or info.get("pod_log_file"):
+                    print(f"      - description_file: {info.get('description_file','')}")
+                    print(f"      - pod_log_file: {info.get('pod_log_file','')}")
+    if skipped:
+        print()
+        print(color("Skipped / Unreachable clusters:", RED))
+        for c, msg in skipped.items():
+            print(color(f"  {c}: {msg}", RED))
+
+# ---------------------------
+# global patterns (populated in parse_args)
+# ---------------------------
+_INCLUDE_PATTERNS: Optional[List[Pattern]] = None
+_EXCLUDE_PATTERNS: Optional[List[Pattern]] = None
+
+# ---------------------------
+# argument parsing
+# ---------------------------
+def print_usage_and_exit() -> None:
+    print("""
+Usage:
+  oc_get_ooms.py [--current] [--contexts ctxA,ctxB] [--batch N]
+                 [--ns-batch-size M] [--ns-workers W] [--prom-workers P]
+                 [--skip-prometheus] [--include-ns regex1,regex2] [--exclude-ns regex1,regex2]
+                 [--retries R] [--timeout S] [--help]
+
+Options:
+  --current                Run only on current-context
+  --contexts ctxA,ctxB     Comma-separated contexts
+  --batch N                Cluster-level batch size (default 2)
+  --ns-batch-size M        Number of namespaces in each namespace batch (default 10)
+  --ns-workers W           Thread pool size for oc checks per namespace batch (default 5)
+  --prom-workers P         Thread pool size for Prometheus queries per prom-batch (default = ns-workers)
+  --skip-prometheus        Do not run Prometheus fallback
+  --include-ns regex,...   Comma-separated regex patterns to include (namespace must match any)
+  --exclude-ns regex,...   Comma-separated regex patterns to exclude (if match any -> excluded)
+  --retries R              Number of retries for oc calls (default 3)
+  --timeout S              OC request timeout in seconds used as --request-timeout (default 45)
+  --help                   Show this help
+""")
+    sys.exit(1)
+
+def compile_patterns(csv_patterns: Optional[str]) -> Optional[List[Pattern]]:
+    if not csv_patterns:
+        return None
+    parts = [p.strip() for p in csv_patterns.split(",") if p.strip()]
+    if not parts:
+        return None
+    try:
+        return [re.compile(p) for p in parts]
+    except re.error as e:
+        print(color(f"Invalid regex in patterns: {e}", RED))
+        sys.exit(1)
+
+def parse_args(argv: List[str]) -> Tuple[List[str], int, int, int, int, int, bool, int]:
+    args = list(argv)
+    if "--help" in args:
+        print_usage_and_exit()
+
+    contexts: List[str] = []
+    batch_size = 2
+    ns_batch_size = DEFAULT_NS_BATCH_SIZE
+    ns_workers = DEFAULT_NS_WORKERS
+    prom_workers = None
+    skip_prometheus = False
+    retries = DEFAULT_RETRIES
+    oc_timeout_seconds = DEFAULT_OC_TIMEOUT
+    include_csv = None
+    exclude_csv = None
+
+    if "--current" in args:
+        cur = get_current_context(retries=retries, oc_timeout_seconds=oc_timeout_seconds)
+        if cur:
+            contexts = [cur]
+    elif "--contexts" in args:
+        i = args.index("--contexts")
+        if i + 1 >= len(args):
+            print(color("ERROR: missing argument for --contexts", RED))
+            print_usage_and_exit()
+        contexts = [c.strip() for c in args[i+1].split(",") if c.strip()]
+    else:
+        contexts = get_all_contexts(retries=retries, oc_timeout_seconds=oc_timeout_seconds)
+
+    if "--batch" in args:
+        i = args.index("--batch")
+        try:
+            batch_size = int(args[i+1])
+        except Exception:
+            print(color("ERROR: invalid --batch value", RED))
+            print_usage_and_exit()
+
+    if "--ns-batch-size" in args:
+        i = args.index("--ns-batch-size")
+        try:
+            ns_batch_size = int(args[i+1])
+        except Exception:
+            print(color("ERROR: invalid --ns-batch-size value", RED))
+            print_usage_and_exit()
+
+    if "--ns-workers" in args:
+        i = args.index("--ns-workers")
+        try:
+            ns_workers = int(args[i+1])
+        except Exception:
+            print(color("ERROR: invalid --ns-workers value", RED))
+            print_usage_and_exit()
+
+    if "--prom-workers" in args:
+        i = args.index("--prom-workers")
+        try:
+            prom_workers = int(args[i+1])
+        except Exception:
+            print(color("ERROR: invalid --prom-workers value", RED))
+            print_usage_and_exit()
+
+    if "--skip-prometheus" in args:
+        skip_prometheus = True
+
+    if "--include-ns" in args:
+        i = args.index("--include-ns")
+        include_csv = args[i+1] if i+1 < len(args) else None
+
+    if "--exclude-ns" in args:
+        i = args.index("--exclude-ns")
+        exclude_csv = args[i+1] if i+1 < len(args) else None
+
+    if "--retries" in args:
+        i = args.index("--retries")
+        try:
+            retries = int(args[i+1])
+        except Exception:
+            print(color("ERROR: invalid --retries value", RED))
+            print_usage_and_exit()
+
+    if "--timeout" in args:
+        i = args.index("--timeout")
+        try:
+            oc_timeout_seconds = int(args[i+1])
+        except Exception:
+            print(color("ERROR: invalid --timeout value", RED))
+            print_usage_and_exit()
+
+    global _INCLUDE_PATTERNS, _EXCLUDE_PATTERNS
+    _INCLUDE_PATTERNS = compile_patterns(include_csv)
+    _EXCLUDE_PATTERNS = compile_patterns(exclude_csv)
+
+    if prom_workers is None:
+        prom_workers = ns_workers
+
+    return contexts, batch_size, ns_batch_size, ns_workers, prom_workers, skip_prometheus, retries, oc_timeout_seconds
+
+# ---------------------------
+# main
+# ---------------------------
+def main() -> None:
+    contexts, batch_size, ns_batch_size, ns_workers, prom_workers, skip_prometheus, retries, oc_timeout_seconds = parse_args(sys.argv[1:])
+
+    if not contexts:
+        print(color("No contexts discovered. Exiting.", RED))
+        sys.exit(1)
+
+    print(color(f"Using contexts: {contexts}", BLUE))
+    print(color(f"Cluster-batch: {batch_size}  NS-batch-size: {ns_batch_size}  NS-workers: {ns_workers}  Prom-workers: {prom_workers}", BLUE))
+    print(color(f"Retries: {retries}  OC timeout(s): {oc_timeout_seconds}s  Skip-prometheus: {skip_prometheus}", BLUE))
+    if _INCLUDE_PATTERNS:
+        print(color(f"Include namespace patterns: {[p.pattern for p in _INCLUDE_PATTERNS]}", BLUE))
+    if _EXCLUDE_PATTERNS:
+        print(color(f"Exclude namespace patterns: {[p.pattern for p in _EXCLUDE_PATTERNS]}", BLUE))
+
+    results, skipped = run_batches(contexts, batch_size, retries, oc_timeout_seconds, ns_batch_size, ns_workers, prom_workers, skip_prometheus)
+
+    json_path = Path("oom_results.json")
+    csv_path = Path("oom_results.csv")
+    export_results(results, json_path, csv_path)
+
+    pretty_print(results, skipped)
+
+    if skipped:
+        print(color("\nSome clusters were skipped due to connectivity errors (see messages above).", YELLOW))
+
+    print(color("\nPer-cluster logs written to /tmp/<cluster>/ (if any findings were found)", GREEN))
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
Already described in 'README.md', but highlighted here as well:
## What This Tool Does

- Scans **one or many OpenShift clusters** (`oc` contexts)
- Detects:
  - **OOMKilled pods**
  - **CrashLoopBackOff pods**
- Looks back across **multiple time windows**:
  - 1h, 3h, 6h, 24h, 48h, 3d, 5d, 7d
- Uses:
  - Kubernetes **events** first (fast)
  - **Prometheus fallback** for older history
- Runs **highly parallel**:
  - Cluster-level batching
  - Namespace-level batching
- Saves **forensic artifacts**:
  - `oc describe pod`
  - `oc logs` (or `--previous`)
- Exports **CSV + JSON** with absolute paths to artifacts
- Colorized terminal output

## Sample output run:
```shell
bash-5.3$ ~/oc_get_ooms.py --ns-batch-size 100 --ns-workers 100 --timeout 120 --batch 4
Using contexts: ['default/api-kflux-ocp-p01-7ayg-p1-openshiftapps-com:6443/smodak', 'default/api-kflux-osp-p01-yt45-p1-openshiftapps-com:6443/smodak', 'default/api-kflux-prd-es01-1ion-p1-openshiftapps-com:6443/smodak', 'default/api-kflux-prd-rh02-0fk9-p1-openshiftapps-com:6443/smodak', 'default/api-kflux-prd-rh03-nnv1-p1-openshiftapps-com:6443/smodak', 'default/api-kflux-rhel-p01-fc38-p1-openshiftapps-com:6443/smodak', 'default/api-kflux-stg-es01-21tc-p1-openshiftapps-com:6443/smodak', 'default/api-stone-prd-rh01-pg1f-p1-openshiftapps-com:6443/smodak', 'default/api-stone-prod-p01-wcfb-p1-openshiftapps-com:6443/smodak', 'default/api-stone-prod-p02-hjvn-p1-openshiftapps-com:6443/smodak', 'default/api-stone-stage-p01-hpmt-p1-openshiftapps-com:6443/smodak', 'default/api-stone-stg-rh01-l2vh-p1-openshiftapps-com:6443/smodak']
Cluster-batch: 4  NS-batch-size: 100  NS-workers: 100  Prom-workers: 100
Retries: 3  OC timeout(s): 120s  Skip-prometheus: False

=== Cluster batch 1: ['default/api-kflux-ocp-p01-7ayg-p1-openshiftapps-com:6443/smodak', 'default/api-kflux-osp-p01-yt45-p1-openshiftapps-com:6443/smodak', 'default/api-kflux-prd-es01-1ion-p1-openshiftapps-com:6443/smodak', 'default/api-kflux-prd-rh02-0fk9-p1-openshiftapps-com:6443/smodak'] ===

→ Processing cluster: kflux-ocp-p01

→ Processing cluster: kflux-osp-p01
→ Processing cluster: kflux-prd-es01


→ Processing cluster: kflux-prd-rh02
  Namespace batch 1: 100 namespaces
  Namespace batch 1: 100 namespaces
  Namespace batch 1: 100 namespaces
  Namespace batch 1: 100 namespaces
  Namespace batch 2: 70 namespaces
    Namespace clusters-611e937f-5577-47db-a301-cd73c98d6e99: 5 pod(s) found via oc
    Namespace clusters-dff42627-b5e9-46f1-b161-bdf5fc302c57: 5 pod(s) found via oc
    Namespace clusters-05444e73-dd68-48b6-899e-0a807a4eb1b3: 5 pod(s) found via oc
  Namespace batch 2: 100 namespaces
    Namespace clusters-2ecdf824-659a-43b4-8432-507e3398f8d0: 5 pod(s) found via oc
  Namespace batch 2: 48 namespaces
    Namespace pulp-access-controller: 1 pod(s) found via oc
  Running Prometheus fallback for 144 namespace(s) in batches
    Prom batch 1: 100 namespaces
    Prom batch 2: 44 namespaces
Completed cluster kflux-prd-es01
  Running Prometheus fallback for 170 namespace(s) in batches
    Prom batch 1: 100 namespaces
  Namespace batch 3: 23 namespaces
    Prom batch 2: 70 namespaces
Completed cluster kflux-osp-p01
  Running Prometheus fallback for 222 namespace(s) in batches
    Prom batch 1: 100 namespaces
    Prom batch 2: 100 namespaces
    Prom batch 3: 22 namespaces
Completed cluster kflux-prd-rh02
  Namespace batch 2: 100 namespaces
  Namespace batch 3: 23 namespaces
  Running Prometheus fallback for 223 namespace(s) in batches
    Prom batch 1: 100 namespaces
    Prom batch 2: 100 namespaces
    Prom batch 3: 23 namespaces
Completed cluster kflux-ocp-p01

=== Cluster batch 2: ['default/api-kflux-prd-rh03-nnv1-p1-openshiftapps-com:6443/smodak', 'default/api-kflux-rhel-p01-fc38-p1-openshiftapps-com:6443/smodak', 'default/api-kflux-stg-es01-21tc-p1-openshiftapps-com:6443/smodak', 'default/api-stone-prd-rh01-pg1f-p1-openshiftapps-com:6443/smodak'] ===

→ Processing cluster: kflux-prd-rh03

→ Processing cluster: kflux-rhel-p01
→ Processing cluster: kflux-stg-es01


→ Processing cluster: stone-prd-rh01
  Namespace batch 1: 100 namespaces
  Namespace batch 1: 100 namespaces
  Namespace batch 1: 100 namespaces
  Namespace batch 1: 100 namespaces
  Namespace batch 2: 35 namespaces
  Running Prometheus fallback for 135 namespace(s) in batches
    Prom batch 1: 100 namespaces
    Prom batch 2: 35 namespaces
Completed cluster kflux-stg-es01
  Namespace batch 2: 100 namespaces
  Namespace batch 2: 100 namespaces
  Namespace batch 3: 100 namespaces
  Namespace batch 3: 100 namespaces
  Namespace batch 4: 74 namespaces
  Running Prometheus fallback for 374 namespace(s) in batches
    Prom batch 1: 100 namespaces
  Namespace batch 2: 100 namespaces
    Prom batch 2: 100 namespaces
    Prom batch 3: 100 namespaces
    Prom batch 4: 74 namespaces
Completed cluster kflux-rhel-p01
  Namespace batch 4: 100 namespaces
  Namespace batch 5: 100 namespaces
  Namespace batch 3: 13 namespaces
  Running Prometheus fallback for 213 namespace(s) in batches
    Prom batch 1: 100 namespaces
    Prom batch 2: 100 namespaces
    Prom batch 3: 13 namespaces
Completed cluster kflux-prd-rh03
  Namespace batch 6: 100 namespaces
  Namespace batch 7: 100 namespaces
  Namespace batch 8: 100 namespaces
  Namespace batch 9: 100 namespaces
  Namespace batch 10: 100 namespaces
  Namespace batch 11: 100 namespaces
  Namespace batch 12: 100 namespaces
  Namespace batch 13: 100 namespaces
  Namespace batch 14: 100 namespaces
  Namespace batch 15: 100 namespaces
  Namespace batch 16: 100 namespaces
  Namespace batch 17: 100 namespaces
  Namespace batch 18: 100 namespaces
  Namespace batch 19: 100 namespaces
  Namespace batch 20: 100 namespaces
  Namespace batch 21: 97 namespaces
  Running Prometheus fallback for 2097 namespace(s) in batches
    Prom batch 1: 100 namespaces
    Prom batch 2: 100 namespaces
    Prom batch 3: 100 namespaces
    Prom batch 4: 100 namespaces
    Prom batch 5: 100 namespaces
    Prom batch 6: 100 namespaces
    Prom batch 7: 100 namespaces
    Prom batch 8: 100 namespaces
    Prom batch 9: 100 namespaces
    Prom batch 10: 100 namespaces
    Prom batch 11: 100 namespaces
    Prom batch 12: 100 namespaces
    Prom batch 13: 100 namespaces
    Prom batch 14: 100 namespaces
    Prom batch 15: 100 namespaces
    Prom batch 16: 100 namespaces
    Prom batch 17: 100 namespaces
    Prom batch 18: 100 namespaces
    Prom batch 19: 100 namespaces
    Prom batch 20: 100 namespaces
    Prom batch 21: 97 namespaces
Completed cluster stone-prd-rh01

=== Cluster batch 3: ['default/api-stone-prod-p01-wcfb-p1-openshiftapps-com:6443/smodak', 'default/api-stone-prod-p02-hjvn-p1-openshiftapps-com:6443/smodak', 'default/api-stone-stage-p01-hpmt-p1-openshiftapps-com:6443/smodak', 'default/api-stone-stg-rh01-l2vh-p1-openshiftapps-com:6443/smodak'] ===

→ Processing cluster: stone-prod-p01

→ Processing cluster: stone-prod-p02

→ Processing cluster: stone-stage-p01

→ Processing cluster: stone-stg-rh01
  Namespace batch 1: 100 namespaces
  Namespace batch 1: 100 namespaces
  Namespace batch 1: 100 namespaces
  Namespace batch 1: 100 namespaces
  Namespace batch 2: 100 namespaces
  Namespace batch 2: 100 namespaces
  Namespace batch 2: 100 namespaces
  Namespace batch 3: 100 namespaces
  Namespace batch 3: 100 namespaces
  Namespace batch 2: 100 namespaces
  Namespace batch 4: 100 namespaces
  Namespace batch 5: 100 namespaces
  Namespace batch 3: 100 namespaces
  Namespace batch 6: 100 namespaces
  Namespace batch 7: 100 namespaces
  Namespace batch 4: 100 namespaces
  Namespace batch 5: 28 namespaces
  Running Prometheus fallback for 428 namespace(s) in batches
    Prom batch 1: 100 namespaces
    Prom batch 2: 100 namespaces
    Prom batch 3: 100 namespaces
    Prom batch 4: 100 namespaces
  Namespace batch 3: 40 namespaces
    Prom batch 5: 28 namespaces
Completed cluster stone-prod-p01
  Running Prometheus fallback for 240 namespace(s) in batches
    Prom batch 1: 100 namespaces
  Namespace batch 4: 100 namespaces
    Prom batch 2: 100 namespaces
    Namespace pulp-access-controller: 1 pod(s) found via oc
    Prom batch 3: 40 namespaces
Completed cluster stone-stage-p01
  Namespace batch 5: 100 namespaces
  Namespace batch 6: 100 namespaces
  Namespace batch 7: 100 namespaces
  Namespace batch 8: 100 namespaces
  Namespace batch 9: 29 namespaces
  Running Prometheus fallback for 828 namespace(s) in batches
    Prom batch 1: 100 namespaces
    Prom batch 2: 100 namespaces
    Prom batch 3: 100 namespaces
    Prom batch 4: 100 namespaces
    Prom batch 5: 100 namespaces
    Prom batch 6: 100 namespaces
    Prom batch 7: 100 namespaces
    Prom batch 8: 100 namespaces
    Prom batch 9: 28 namespaces
Completed cluster stone-stg-rh01
  Namespace batch 8: 100 namespaces
  Namespace batch 9: 100 namespaces
    Namespace pulp-access-controller: 1 pod(s) found via oc
  Namespace batch 10: 100 namespaces
  Namespace batch 11: 100 namespaces
    Namespace rhoai-tenant: 3 pod(s) found via oc
  Namespace batch 12: 100 namespaces
  Namespace batch 13: 86 namespaces
  Running Prometheus fallback for 1284 namespace(s) in batches
    Prom batch 1: 100 namespaces
    Prom batch 2: 100 namespaces
    Prom batch 3: 100 namespaces
    Prom batch 4: 100 namespaces
    Prom batch 5: 100 namespaces
    Prom batch 6: 100 namespaces
    Prom batch 7: 100 namespaces
    Prom batch 8: 100 namespaces
    Prom batch 9: 100 namespaces
    Prom batch 10: 100 namespaces
    Prom batch 11: 100 namespaces
    Prom batch 12: 100 namespaces
    Prom batch 13: 84 namespaces
Completed cluster stone-prod-p02
JSON written → oom_results.json
CSV written → oom_results.csv

Cluster: kflux-prd-es01
  Namespace: clusters-611e937f-5577-47db-a301-cd73c98d6e99
    Pod: catalog-operator-866d64458-dmk2x
      - CrashLoopBackOff event at: 2025-12-12T06:05:46Z
      - description_file: /private/tmp/kflux-prd-es01/clusters-611e937f-5577-47db-a301-cd73c98d6e99__catalog-operator-866d64458-dmk2x__20251212T065132Z__desc.txt
      - pod_log_file: /private/tmp/kflux-prd-es01/clusters-611e937f-5577-47db-a301-cd73c98d6e99__catalog-operator-866d64458-dmk2x__20251212T065132Z__log.txt
    Pod: certified-operators-catalog-79757bd797-wtthq
      - CrashLoopBackOff event at: 2025-12-12T06:05:36Z
      - description_file: /private/tmp/kflux-prd-es01/clusters-611e937f-5577-47db-a301-cd73c98d6e99__certified-operators-catalog-79757bd797-wtthq__20251212T065140Z__desc.txt
      - pod_log_file: /private/tmp/kflux-prd-es01/clusters-611e937f-5577-47db-a301-cd73c98d6e99__certified-operators-catalog-79757bd797-wtthq__20251212T065140Z__log.txt
    Pod: community-operators-catalog-6844d5696f-lj68d
      - CrashLoopBackOff event at: 2025-12-12T06:05:37Z
      - description_file: /private/tmp/kflux-prd-es01/clusters-611e937f-5577-47db-a301-cd73c98d6e99__community-operators-catalog-6844d5696f-lj68d__20251212T065142Z__desc.txt
      - pod_log_file: /private/tmp/kflux-prd-es01/clusters-611e937f-5577-47db-a301-cd73c98d6e99__community-operators-catalog-6844d5696f-lj68d__20251212T065142Z__log.txt
    Pod: redhat-marketplace-catalog-556cf7f5fd-b72cg
      - CrashLoopBackOff event at: 2025-12-12T06:05:37Z
      - description_file: /private/tmp/kflux-prd-es01/clusters-611e937f-5577-47db-a301-cd73c98d6e99__redhat-marketplace-catalog-556cf7f5fd-b72cg__20251212T065143Z__desc.txt
      - pod_log_file: /private/tmp/kflux-prd-es01/clusters-611e937f-5577-47db-a301-cd73c98d6e99__redhat-marketplace-catalog-556cf7f5fd-b72cg__20251212T065143Z__log.txt
    Pod: redhat-operators-catalog-6b8bd8fc8f-mg227
      - CrashLoopBackOff event at: 2025-12-12T06:05:38Z
      - description_file: /private/tmp/kflux-prd-es01/clusters-611e937f-5577-47db-a301-cd73c98d6e99__redhat-operators-catalog-6b8bd8fc8f-mg227__20251212T065144Z__desc.txt
      - pod_log_file: /private/tmp/kflux-prd-es01/clusters-611e937f-5577-47db-a301-cd73c98d6e99__redhat-operators-catalog-6b8bd8fc8f-mg227__20251212T065144Z__log.txt
  Namespace: clusters-dff42627-b5e9-46f1-b161-bdf5fc302c57
    Pod: catalog-operator-5948b97f7d-85bzm
      - CrashLoopBackOff event at: 2025-12-12T06:44:59Z
      - description_file: /private/tmp/kflux-prd-es01/clusters-dff42627-b5e9-46f1-b161-bdf5fc302c57__catalog-operator-5948b97f7d-85bzm__20251212T065148Z__desc.txt
      - pod_log_file: /private/tmp/kflux-prd-es01/clusters-dff42627-b5e9-46f1-b161-bdf5fc302c57__catalog-operator-5948b97f7d-85bzm__20251212T065148Z__log.txt
    Pod: certified-operators-catalog-74dbb8f6c5-tb6nz
      - CrashLoopBackOff event at: 2025-12-12T06:44:51Z
      - description_file: /private/tmp/kflux-prd-es01/clusters-dff42627-b5e9-46f1-b161-bdf5fc302c57__certified-operators-catalog-74dbb8f6c5-tb6nz__20251212T065156Z__desc.txt
      - pod_log_file: /private/tmp/kflux-prd-es01/clusters-dff42627-b5e9-46f1-b161-bdf5fc302c57__certified-operators-catalog-74dbb8f6c5-tb6nz__20251212T065156Z__log.txt
    Pod: community-operators-catalog-575fbfb7c5-9qr4p
      - CrashLoopBackOff event at: 2025-12-12T06:44:51Z
      - description_file: /private/tmp/kflux-prd-es01/clusters-dff42627-b5e9-46f1-b161-bdf5fc302c57__community-operators-catalog-575fbfb7c5-9qr4p__20251212T065158Z__desc.txt
      - pod_log_file: /private/tmp/kflux-prd-es01/clusters-dff42627-b5e9-46f1-b161-bdf5fc302c57__community-operators-catalog-575fbfb7c5-9qr4p__20251212T065158Z__log.txt
    Pod: redhat-marketplace-catalog-5fff54d476-4hppf
      - CrashLoopBackOff event at: 2025-12-12T06:44:51Z
      - description_file: /private/tmp/kflux-prd-es01/clusters-dff42627-b5e9-46f1-b161-bdf5fc302c57__redhat-marketplace-catalog-5fff54d476-4hppf__20251212T065159Z__desc.txt
      - pod_log_file: /private/tmp/kflux-prd-es01/clusters-dff42627-b5e9-46f1-b161-bdf5fc302c57__redhat-marketplace-catalog-5fff54d476-4hppf__20251212T065159Z__log.txt
    Pod: redhat-operators-catalog-7cd6f8cddc-2bk5k
      - CrashLoopBackOff event at: 2025-12-12T06:44:51Z
      - description_file: /private/tmp/kflux-prd-es01/clusters-dff42627-b5e9-46f1-b161-bdf5fc302c57__redhat-operators-catalog-7cd6f8cddc-2bk5k__20251212T065200Z__desc.txt
      - pod_log_file: /private/tmp/kflux-prd-es01/clusters-dff42627-b5e9-46f1-b161-bdf5fc302c57__redhat-operators-catalog-7cd6f8cddc-2bk5k__20251212T065200Z__log.txt
  Namespace: clusters-05444e73-dd68-48b6-899e-0a807a4eb1b3
    Pod: catalog-operator-74999f6f44-wv46s
      - CrashLoopBackOff event at: 2025-12-12T06:35:38Z
      - description_file: /private/tmp/kflux-prd-es01/clusters-05444e73-dd68-48b6-899e-0a807a4eb1b3__catalog-operator-74999f6f44-wv46s__20251212T065201Z__desc.txt
      - pod_log_file: /private/tmp/kflux-prd-es01/clusters-05444e73-dd68-48b6-899e-0a807a4eb1b3__catalog-operator-74999f6f44-wv46s__20251212T065201Z__log.txt
    Pod: certified-operators-catalog-d5b7b896b-q5s2r
      - CrashLoopBackOff event at: 2025-12-12T06:35:28Z
      - description_file: /private/tmp/kflux-prd-es01/clusters-05444e73-dd68-48b6-899e-0a807a4eb1b3__certified-operators-catalog-d5b7b896b-q5s2r__20251212T065201Z__desc.txt
      - pod_log_file: /private/tmp/kflux-prd-es01/clusters-05444e73-dd68-48b6-899e-0a807a4eb1b3__certified-operators-catalog-d5b7b896b-q5s2r__20251212T065201Z__log.txt
    Pod: community-operators-catalog-66f496b886-v6bk2
      - CrashLoopBackOff event at: 2025-12-12T06:35:28Z
      - description_file: /private/tmp/kflux-prd-es01/clusters-05444e73-dd68-48b6-899e-0a807a4eb1b3__community-operators-catalog-66f496b886-v6bk2__20251212T065203Z__desc.txt
      - pod_log_file: /private/tmp/kflux-prd-es01/clusters-05444e73-dd68-48b6-899e-0a807a4eb1b3__community-operators-catalog-66f496b886-v6bk2__20251212T065203Z__log.txt
    Pod: redhat-marketplace-catalog-db87499f5-w9qgc
      - CrashLoopBackOff event at: 2025-12-12T06:35:28Z
      - description_file: /private/tmp/kflux-prd-es01/clusters-05444e73-dd68-48b6-899e-0a807a4eb1b3__redhat-marketplace-catalog-db87499f5-w9qgc__20251212T065203Z__desc.txt
      - pod_log_file: /private/tmp/kflux-prd-es01/clusters-05444e73-dd68-48b6-899e-0a807a4eb1b3__redhat-marketplace-catalog-db87499f5-w9qgc__20251212T065203Z__log.txt
    Pod: redhat-operators-catalog-7fdf966868-lld94
      - CrashLoopBackOff event at: 2025-12-12T06:35:28Z
      - description_file: /private/tmp/kflux-prd-es01/clusters-05444e73-dd68-48b6-899e-0a807a4eb1b3__redhat-operators-catalog-7fdf966868-lld94__20251212T065204Z__desc.txt
      - pod_log_file: /private/tmp/kflux-prd-es01/clusters-05444e73-dd68-48b6-899e-0a807a4eb1b3__redhat-operators-catalog-7fdf966868-lld94__20251212T065204Z__log.txt
  Namespace: clusters-2ecdf824-659a-43b4-8432-507e3398f8d0
    Pod: catalog-operator-68f979975b-ls94l
      - CrashLoopBackOff event at: 2025-12-12T06:05:58Z
      - description_file: /private/tmp/kflux-prd-es01/clusters-2ecdf824-659a-43b4-8432-507e3398f8d0__catalog-operator-68f979975b-ls94l__20251212T065205Z__desc.txt
      - pod_log_file: /private/tmp/kflux-prd-es01/clusters-2ecdf824-659a-43b4-8432-507e3398f8d0__catalog-operator-68f979975b-ls94l__20251212T065205Z__log.txt
    Pod: certified-operators-catalog-79795d58-87w4n
      - CrashLoopBackOff event at: 2025-12-12T06:05:40Z
      - description_file: /private/tmp/kflux-prd-es01/clusters-2ecdf824-659a-43b4-8432-507e3398f8d0__certified-operators-catalog-79795d58-87w4n__20251212T065206Z__desc.txt
      - pod_log_file: /private/tmp/kflux-prd-es01/clusters-2ecdf824-659a-43b4-8432-507e3398f8d0__certified-operators-catalog-79795d58-87w4n__20251212T065206Z__log.txt
    Pod: community-operators-catalog-798596ff98-cjvxg
      - CrashLoopBackOff event at: 2025-12-12T06:05:40Z
      - description_file: /private/tmp/kflux-prd-es01/clusters-2ecdf824-659a-43b4-8432-507e3398f8d0__community-operators-catalog-798596ff98-cjvxg__20251212T065206Z__desc.txt
      - pod_log_file: /private/tmp/kflux-prd-es01/clusters-2ecdf824-659a-43b4-8432-507e3398f8d0__community-operators-catalog-798596ff98-cjvxg__20251212T065206Z__log.txt
    Pod: redhat-marketplace-catalog-5c7bc7b49f-cs8sr
      - CrashLoopBackOff event at: 2025-12-12T06:05:40Z
      - description_file: /private/tmp/kflux-prd-es01/clusters-2ecdf824-659a-43b4-8432-507e3398f8d0__redhat-marketplace-catalog-5c7bc7b49f-cs8sr__20251212T065207Z__desc.txt
      - pod_log_file: /private/tmp/kflux-prd-es01/clusters-2ecdf824-659a-43b4-8432-507e3398f8d0__redhat-marketplace-catalog-5c7bc7b49f-cs8sr__20251212T065207Z__log.txt
    Pod: redhat-operators-catalog-7f6767649b-4wr8q
      - CrashLoopBackOff event at: 2025-12-12T06:05:40Z
      - description_file: /private/tmp/kflux-prd-es01/clusters-2ecdf824-659a-43b4-8432-507e3398f8d0__redhat-operators-catalog-7f6767649b-4wr8q__20251212T065215Z__desc.txt
      - pod_log_file: /private/tmp/kflux-prd-es01/clusters-2ecdf824-659a-43b4-8432-507e3398f8d0__redhat-operators-catalog-7f6767649b-4wr8q__20251212T065215Z__log.txt

Cluster: kflux-osp-p01
  (no namespaces with OOM/CrashLoopBackOff found)

Cluster: kflux-prd-rh02
  Namespace: pulp-access-controller
    Pod: pulp-access-operator-5dbc87f4-9964v
      - CrashLoopBackOff event at: 2025-12-12T06:49:17Z
      - description_file: /private/tmp/kflux-prd-rh02/pulp-access-controller__pulp-access-operator-5dbc87f4-9964v__20251212T065224Z__desc.txt
      - pod_log_file: /private/tmp/kflux-prd-rh02/pulp-access-controller__pulp-access-operator-5dbc87f4-9964v__20251212T065224Z__log.txt

Cluster: kflux-ocp-p01
  (no namespaces with OOM/CrashLoopBackOff found)

Cluster: kflux-stg-es01
  (no namespaces with OOM/CrashLoopBackOff found)

Cluster: kflux-rhel-p01
  (no namespaces with OOM/CrashLoopBackOff found)

Cluster: kflux-prd-rh03
  (no namespaces with OOM/CrashLoopBackOff found)

Cluster: stone-prd-rh01
  (no namespaces with OOM/CrashLoopBackOff found)

Cluster: stone-prod-p01
  (no namespaces with OOM/CrashLoopBackOff found)

Cluster: stone-stage-p01
  (no namespaces with OOM/CrashLoopBackOff found)

Cluster: stone-stg-rh01
  Namespace: pulp-access-controller
    Pod: pulp-access-operator-5dbc87f4-lb8jf
      - CrashLoopBackOff event at: 2025-12-12T07:16:09Z
      - description_file: /private/tmp/stone-stg-rh01/pulp-access-controller__pulp-access-operator-5dbc87f4-lb8jf__20251212T071736Z__desc.txt
      - pod_log_file: /private/tmp/stone-stg-rh01/pulp-access-controller__pulp-access-operator-5dbc87f4-lb8jf__20251212T071736Z__log.txt

Cluster: stone-prod-p02
  Namespace: pulp-access-controller
    Pod: pulp-access-operator-5dbc87f4-qdmv6
      - CrashLoopBackOff event at: 2025-12-12T07:18:05Z
      - description_file: /private/tmp/stone-prod-p02/pulp-access-controller__pulp-access-operator-5dbc87f4-qdmv6__20251212T072016Z__desc.txt
      - pod_log_file: /private/tmp/stone-prod-p02/pulp-access-controller__pulp-access-operator-5dbc87f4-qdmv6__20251212T072016Z__log.txt
  Namespace: rhoai-tenant
    Pod: mlflow-poc-on-pull-request-kks5p-sast-coverity-check-pod
      - CrashLoopBackOff event at: 2025-12-12T04:54:29Z
      - description_file: /private/tmp/stone-prod-p02/rhoai-tenant__mlflow-poc-on-pull-request-kks5p-sast-coverity-check-pod__20251212T072108Z__desc.txt
      - pod_log_file: /private/tmp/stone-prod-p02/rhoai-tenant__mlflow-poc-on-pull-request-kks5p-sast-coverity-check-pod__20251212T072108Z__log.txt
    Pod: mlflow-poc-on-pull-request-s4f77-sast-coverity-check-pod
      - CrashLoopBackOff event at: 2025-12-12T04:53:18Z
      - CrashLoopBackOff event at: 2025-12-12T04:53:19Z
      - description_file: /private/tmp/stone-prod-p02/rhoai-tenant__mlflow-poc-on-pull-request-s4f77-sast-coverity-check-pod__20251212T072109Z__desc.txt
      - pod_log_file: /private/tmp/stone-prod-p02/rhoai-tenant__mlflow-poc-on-pull-request-s4f77-sast-coverity-check-pod__20251212T072109Z__log.txt
    Pod: rhoai-health-on-pull-request-pdbgb-sast-coverity-check-pod
      - CrashLoopBackOff event at: 2025-12-12T05:09:33Z
      - description_file: /private/tmp/stone-prod-p02/rhoai-tenant__rhoai-health-on-pull-request-pdbgb-sast-coverity-check-pod__20251212T072110Z__desc.txt
      - pod_log_file: /private/tmp/stone-prod-p02/rhoai-tenant__rhoai-health-on-pull-request-pdbgb-sast-coverity-check-pod__20251212T072110Z__log.txt

Per-cluster logs written to /tmp/<cluster>/ (if any findings were found)
```

### Files generated (oom_results.csv):
```shell
bash-5.3$ cat oom_results.csv 
cluster,namespace,pod,type,timestamps,sources,description_file,pod_log_file
kflux-prd-es01,clusters-611e937f-5577-47db-a301-cd73c98d6e99,catalog-operator-866d64458-dmk2x,CrashLoopBackOff,2025-12-12T06:05:46Z,events,/private/tmp/kflux-prd-es01/clusters-611e937f-5577-47db-a301-cd73c98d6e99__catalog-operator-866d64458-dmk2x__20251212T065132Z__desc.txt,/private/tmp/kflux-prd-es01/clusters-611e937f-5577-47db-a301-cd73c98d6e99__catalog-operator-866d64458-dmk2x__20251212T065132Z__log.txt
kflux-prd-es01,clusters-611e937f-5577-47db-a301-cd73c98d6e99,certified-operators-catalog-79757bd797-wtthq,CrashLoopBackOff,2025-12-12T06:05:36Z,events,/private/tmp/kflux-prd-es01/clusters-611e937f-5577-47db-a301-cd73c98d6e99__certified-operators-catalog-79757bd797-wtthq__20251212T065140Z__desc.txt,/private/tmp/kflux-prd-es01/clusters-611e937f-5577-47db-a301-cd73c98d6e99__certified-operators-catalog-79757bd797-wtthq__20251212T065140Z__log.txt
kflux-prd-es01,clusters-611e937f-5577-47db-a301-cd73c98d6e99,community-operators-catalog-6844d5696f-lj68d,CrashLoopBackOff,2025-12-12T06:05:37Z,events,/private/tmp/kflux-prd-es01/clusters-611e937f-5577-47db-a301-cd73c98d6e99__community-operators-catalog-6844d5696f-lj68d__20251212T065142Z__desc.txt,/private/tmp/kflux-prd-es01/clusters-611e937f-5577-47db-a301-cd73c98d6e99__community-operators-catalog-6844d5696f-lj68d__20251212T065142Z__log.txt
kflux-prd-es01,clusters-611e937f-5577-47db-a301-cd73c98d6e99,redhat-marketplace-catalog-556cf7f5fd-b72cg,CrashLoopBackOff,2025-12-12T06:05:37Z,events,/private/tmp/kflux-prd-es01/clusters-611e937f-5577-47db-a301-cd73c98d6e99__redhat-marketplace-catalog-556cf7f5fd-b72cg__20251212T065143Z__desc.txt,/private/tmp/kflux-prd-es01/clusters-611e937f-5577-47db-a301-cd73c98d6e99__redhat-marketplace-catalog-556cf7f5fd-b72cg__20251212T065143Z__log.txt
kflux-prd-es01,clusters-611e937f-5577-47db-a301-cd73c98d6e99,redhat-operators-catalog-6b8bd8fc8f-mg227,CrashLoopBackOff,2025-12-12T06:05:38Z,events,/private/tmp/kflux-prd-es01/clusters-611e937f-5577-47db-a301-cd73c98d6e99__redhat-operators-catalog-6b8bd8fc8f-mg227__20251212T065144Z__desc.txt,/private/tmp/kflux-prd-es01/clusters-611e937f-5577-47db-a301-cd73c98d6e99__redhat-operators-catalog-6b8bd8fc8f-mg227__20251212T065144Z__log.txt
kflux-prd-es01,clusters-dff42627-b5e9-46f1-b161-bdf5fc302c57,catalog-operator-5948b97f7d-85bzm,CrashLoopBackOff,2025-12-12T06:44:59Z,events,/private/tmp/kflux-prd-es01/clusters-dff42627-b5e9-46f1-b161-bdf5fc302c57__catalog-operator-5948b97f7d-85bzm__20251212T065148Z__desc.txt,/private/tmp/kflux-prd-es01/clusters-dff42627-b5e9-46f1-b161-bdf5fc302c57__catalog-operator-5948b97f7d-85bzm__20251212T065148Z__log.txt
kflux-prd-es01,clusters-dff42627-b5e9-46f1-b161-bdf5fc302c57,certified-operators-catalog-74dbb8f6c5-tb6nz,CrashLoopBackOff,2025-12-12T06:44:51Z,events,/private/tmp/kflux-prd-es01/clusters-dff42627-b5e9-46f1-b161-bdf5fc302c57__certified-operators-catalog-74dbb8f6c5-tb6nz__20251212T065156Z__desc.txt,/private/tmp/kflux-prd-es01/clusters-dff42627-b5e9-46f1-b161-bdf5fc302c57__certified-operators-catalog-74dbb8f6c5-tb6nz__20251212T065156Z__log.txt
kflux-prd-es01,clusters-dff42627-b5e9-46f1-b161-bdf5fc302c57,community-operators-catalog-575fbfb7c5-9qr4p,CrashLoopBackOff,2025-12-12T06:44:51Z,events,/private/tmp/kflux-prd-es01/clusters-dff42627-b5e9-46f1-b161-bdf5fc302c57__community-operators-catalog-575fbfb7c5-9qr4p__20251212T065158Z__desc.txt,/private/tmp/kflux-prd-es01/clusters-dff42627-b5e9-46f1-b161-bdf5fc302c57__community-operators-catalog-575fbfb7c5-9qr4p__20251212T065158Z__log.txt
kflux-prd-es01,clusters-dff42627-b5e9-46f1-b161-bdf5fc302c57,redhat-marketplace-catalog-5fff54d476-4hppf,CrashLoopBackOff,2025-12-12T06:44:51Z,events,/private/tmp/kflux-prd-es01/clusters-dff42627-b5e9-46f1-b161-bdf5fc302c57__redhat-marketplace-catalog-5fff54d476-4hppf__20251212T065159Z__desc.txt,/private/tmp/kflux-prd-es01/clusters-dff42627-b5e9-46f1-b161-bdf5fc302c57__redhat-marketplace-catalog-5fff54d476-4hppf__20251212T065159Z__log.txt
kflux-prd-es01,clusters-dff42627-b5e9-46f1-b161-bdf5fc302c57,redhat-operators-catalog-7cd6f8cddc-2bk5k,CrashLoopBackOff,2025-12-12T06:44:51Z,events,/private/tmp/kflux-prd-es01/clusters-dff42627-b5e9-46f1-b161-bdf5fc302c57__redhat-operators-catalog-7cd6f8cddc-2bk5k__20251212T065200Z__desc.txt,/private/tmp/kflux-prd-es01/clusters-dff42627-b5e9-46f1-b161-bdf5fc302c57__redhat-operators-catalog-7cd6f8cddc-2bk5k__20251212T065200Z__log.txt
kflux-prd-es01,clusters-05444e73-dd68-48b6-899e-0a807a4eb1b3,catalog-operator-74999f6f44-wv46s,CrashLoopBackOff,2025-12-12T06:35:38Z,events,/private/tmp/kflux-prd-es01/clusters-05444e73-dd68-48b6-899e-0a807a4eb1b3__catalog-operator-74999f6f44-wv46s__20251212T065201Z__desc.txt,/private/tmp/kflux-prd-es01/clusters-05444e73-dd68-48b6-899e-0a807a4eb1b3__catalog-operator-74999f6f44-wv46s__20251212T065201Z__log.txt
kflux-prd-es01,clusters-05444e73-dd68-48b6-899e-0a807a4eb1b3,certified-operators-catalog-d5b7b896b-q5s2r,CrashLoopBackOff,2025-12-12T06:35:28Z,events,/private/tmp/kflux-prd-es01/clusters-05444e73-dd68-48b6-899e-0a807a4eb1b3__certified-operators-catalog-d5b7b896b-q5s2r__20251212T065201Z__desc.txt,/private/tmp/kflux-prd-es01/clusters-05444e73-dd68-48b6-899e-0a807a4eb1b3__certified-operators-catalog-d5b7b896b-q5s2r__20251212T065201Z__log.txt
kflux-prd-es01,clusters-05444e73-dd68-48b6-899e-0a807a4eb1b3,community-operators-catalog-66f496b886-v6bk2,CrashLoopBackOff,2025-12-12T06:35:28Z,events,/private/tmp/kflux-prd-es01/clusters-05444e73-dd68-48b6-899e-0a807a4eb1b3__community-operators-catalog-66f496b886-v6bk2__20251212T065203Z__desc.txt,/private/tmp/kflux-prd-es01/clusters-05444e73-dd68-48b6-899e-0a807a4eb1b3__community-operators-catalog-66f496b886-v6bk2__20251212T065203Z__log.txt
kflux-prd-es01,clusters-05444e73-dd68-48b6-899e-0a807a4eb1b3,redhat-marketplace-catalog-db87499f5-w9qgc,CrashLoopBackOff,2025-12-12T06:35:28Z,events,/private/tmp/kflux-prd-es01/clusters-05444e73-dd68-48b6-899e-0a807a4eb1b3__redhat-marketplace-catalog-db87499f5-w9qgc__20251212T065203Z__desc.txt,/private/tmp/kflux-prd-es01/clusters-05444e73-dd68-48b6-899e-0a807a4eb1b3__redhat-marketplace-catalog-db87499f5-w9qgc__20251212T065203Z__log.txt
kflux-prd-es01,clusters-05444e73-dd68-48b6-899e-0a807a4eb1b3,redhat-operators-catalog-7fdf966868-lld94,CrashLoopBackOff,2025-12-12T06:35:28Z,events,/private/tmp/kflux-prd-es01/clusters-05444e73-dd68-48b6-899e-0a807a4eb1b3__redhat-operators-catalog-7fdf966868-lld94__20251212T065204Z__desc.txt,/private/tmp/kflux-prd-es01/clusters-05444e73-dd68-48b6-899e-0a807a4eb1b3__redhat-operators-catalog-7fdf966868-lld94__20251212T065204Z__log.txt
kflux-prd-es01,clusters-2ecdf824-659a-43b4-8432-507e3398f8d0,catalog-operator-68f979975b-ls94l,CrashLoopBackOff,2025-12-12T06:05:58Z,events,/private/tmp/kflux-prd-es01/clusters-2ecdf824-659a-43b4-8432-507e3398f8d0__catalog-operator-68f979975b-ls94l__20251212T065205Z__desc.txt,/private/tmp/kflux-prd-es01/clusters-2ecdf824-659a-43b4-8432-507e3398f8d0__catalog-operator-68f979975b-ls94l__20251212T065205Z__log.txt
kflux-prd-es01,clusters-2ecdf824-659a-43b4-8432-507e3398f8d0,certified-operators-catalog-79795d58-87w4n,CrashLoopBackOff,2025-12-12T06:05:40Z,events,/private/tmp/kflux-prd-es01/clusters-2ecdf824-659a-43b4-8432-507e3398f8d0__certified-operators-catalog-79795d58-87w4n__20251212T065206Z__desc.txt,/private/tmp/kflux-prd-es01/clusters-2ecdf824-659a-43b4-8432-507e3398f8d0__certified-operators-catalog-79795d58-87w4n__20251212T065206Z__log.txt
kflux-prd-es01,clusters-2ecdf824-659a-43b4-8432-507e3398f8d0,community-operators-catalog-798596ff98-cjvxg,CrashLoopBackOff,2025-12-12T06:05:40Z,events,/private/tmp/kflux-prd-es01/clusters-2ecdf824-659a-43b4-8432-507e3398f8d0__community-operators-catalog-798596ff98-cjvxg__20251212T065206Z__desc.txt,/private/tmp/kflux-prd-es01/clusters-2ecdf824-659a-43b4-8432-507e3398f8d0__community-operators-catalog-798596ff98-cjvxg__20251212T065206Z__log.txt
kflux-prd-es01,clusters-2ecdf824-659a-43b4-8432-507e3398f8d0,redhat-marketplace-catalog-5c7bc7b49f-cs8sr,CrashLoopBackOff,2025-12-12T06:05:40Z,events,/private/tmp/kflux-prd-es01/clusters-2ecdf824-659a-43b4-8432-507e3398f8d0__redhat-marketplace-catalog-5c7bc7b49f-cs8sr__20251212T065207Z__desc.txt,/private/tmp/kflux-prd-es01/clusters-2ecdf824-659a-43b4-8432-507e3398f8d0__redhat-marketplace-catalog-5c7bc7b49f-cs8sr__20251212T065207Z__log.txt
kflux-prd-es01,clusters-2ecdf824-659a-43b4-8432-507e3398f8d0,redhat-operators-catalog-7f6767649b-4wr8q,CrashLoopBackOff,2025-12-12T06:05:40Z,events,/private/tmp/kflux-prd-es01/clusters-2ecdf824-659a-43b4-8432-507e3398f8d0__redhat-operators-catalog-7f6767649b-4wr8q__20251212T065215Z__desc.txt,/private/tmp/kflux-prd-es01/clusters-2ecdf824-659a-43b4-8432-507e3398f8d0__redhat-operators-catalog-7f6767649b-4wr8q__20251212T065215Z__log.txt
kflux-prd-rh02,pulp-access-controller,pulp-access-operator-5dbc87f4-9964v,CrashLoopBackOff,2025-12-12T06:49:17Z,events,/private/tmp/kflux-prd-rh02/pulp-access-controller__pulp-access-operator-5dbc87f4-9964v__20251212T065224Z__desc.txt,/private/tmp/kflux-prd-rh02/pulp-access-controller__pulp-access-operator-5dbc87f4-9964v__20251212T065224Z__log.txt
stone-stg-rh01,pulp-access-controller,pulp-access-operator-5dbc87f4-lb8jf,CrashLoopBackOff,2025-12-12T07:16:09Z,events,/private/tmp/stone-stg-rh01/pulp-access-controller__pulp-access-operator-5dbc87f4-lb8jf__20251212T071736Z__desc.txt,/private/tmp/stone-stg-rh01/pulp-access-controller__pulp-access-operator-5dbc87f4-lb8jf__20251212T071736Z__log.txt
stone-prod-p02,pulp-access-controller,pulp-access-operator-5dbc87f4-qdmv6,CrashLoopBackOff,2025-12-12T07:18:05Z,events,/private/tmp/stone-prod-p02/pulp-access-controller__pulp-access-operator-5dbc87f4-qdmv6__20251212T072016Z__desc.txt,/private/tmp/stone-prod-p02/pulp-access-controller__pulp-access-operator-5dbc87f4-qdmv6__20251212T072016Z__log.txt
stone-prod-p02,rhoai-tenant,mlflow-poc-on-pull-request-kks5p-sast-coverity-check-pod,CrashLoopBackOff,2025-12-12T04:54:29Z,events,/private/tmp/stone-prod-p02/rhoai-tenant__mlflow-poc-on-pull-request-kks5p-sast-coverity-check-pod__20251212T072108Z__desc.txt,/private/tmp/stone-prod-p02/rhoai-tenant__mlflow-poc-on-pull-request-kks5p-sast-coverity-check-pod__20251212T072108Z__log.txt
stone-prod-p02,rhoai-tenant,mlflow-poc-on-pull-request-s4f77-sast-coverity-check-pod,CrashLoopBackOff,2025-12-12T04:53:18Z;2025-12-12T04:53:19Z,events,/private/tmp/stone-prod-p02/rhoai-tenant__mlflow-poc-on-pull-request-s4f77-sast-coverity-check-pod__20251212T072109Z__desc.txt,/private/tmp/stone-prod-p02/rhoai-tenant__mlflow-poc-on-pull-request-s4f77-sast-coverity-check-pod__20251212T072109Z__log.txt
stone-prod-p02,rhoai-tenant,rhoai-health-on-pull-request-pdbgb-sast-coverity-check-pod,CrashLoopBackOff,2025-12-12T05:09:33Z,events,/private/tmp/stone-prod-p02/rhoai-tenant__rhoai-health-on-pull-request-pdbgb-sast-coverity-check-pod__20251212T072110Z__desc.txt,/private/tmp/stone-prod-p02/rhoai-tenant__rhoai-health-on-pull-request-pdbgb-sast-coverity-check-pod__20251212T072110Z__log.txt
```

### Files generated (oom_results.json):
```shell
bash-5.3$ cat oom_results.json 
{
  "kflux-prd-es01": {
    "clusters-611e937f-5577-47db-a301-cd73c98d6e99": {
      "catalog-operator-866d64458-dmk2x": {
        "pod": "catalog-operator-866d64458-dmk2x",
        "oom_timestamps": [],
        "crash_timestamps": [
          "2025-12-12T06:05:46Z"
        ],
        "sources": [
          "events"
        ],
        "description_file": "/private/tmp/kflux-prd-es01/clusters-611e937f-5577-47db-a301-cd73c98d6e99__catalog-operator-866d64458-dmk2x__20251212T065132Z__desc.txt",
        "pod_log_file": "/private/tmp/kflux-prd-es01/clusters-611e937f-5577-47db-a301-cd73c98d6e99__catalog-operator-866d64458-dmk2x__20251212T065132Z__log.txt"
      },
      "certified-operators-catalog-79757bd797-wtthq": {
        "pod": "certified-operators-catalog-79757bd797-wtthq",
        "oom_timestamps": [],
        "crash_timestamps": [
          "2025-12-12T06:05:36Z"
        ],
        "sources": [
          "events"
        ],
        "description_file": "/private/tmp/kflux-prd-es01/clusters-611e937f-5577-47db-a301-cd73c98d6e99__certified-operators-catalog-79757bd797-wtthq__20251212T065140Z__desc.txt",
        "pod_log_file": "/private/tmp/kflux-prd-es01/clusters-611e937f-5577-47db-a301-cd73c98d6e99__certified-operators-catalog-79757bd797-wtthq__20251212T065140Z__log.txt"
      },
      "community-operators-catalog-6844d5696f-lj68d": {
        "pod": "community-operators-catalog-6844d5696f-lj68d",
        "oom_timestamps": [],
        "crash_timestamps": [
          "2025-12-12T06:05:37Z"
        ],
        "sources": [
          "events"
        ],
        "description_file": "/private/tmp/kflux-prd-es01/clusters-611e937f-5577-47db-a301-cd73c98d6e99__community-operators-catalog-6844d5696f-lj68d__20251212T065142Z__desc.txt",
        "pod_log_file": "/private/tmp/kflux-prd-es01/clusters-611e937f-5577-47db-a301-cd73c98d6e99__community-operators-catalog-6844d5696f-lj68d__20251212T065142Z__log.txt"
      },
      "redhat-marketplace-catalog-556cf7f5fd-b72cg": {
        "pod": "redhat-marketplace-catalog-556cf7f5fd-b72cg",
        "oom_timestamps": [],
        "crash_timestamps": [
          "2025-12-12T06:05:37Z"
        ],
        "sources": [
          "events"
        ],
        "description_file": "/private/tmp/kflux-prd-es01/clusters-611e937f-5577-47db-a301-cd73c98d6e99__redhat-marketplace-catalog-556cf7f5fd-b72cg__20251212T065143Z__desc.txt",
        "pod_log_file": "/private/tmp/kflux-prd-es01/clusters-611e937f-5577-47db-a301-cd73c98d6e99__redhat-marketplace-catalog-556cf7f5fd-b72cg__20251212T065143Z__log.txt"
      },
      "redhat-operators-catalog-6b8bd8fc8f-mg227": {
        "pod": "redhat-operators-catalog-6b8bd8fc8f-mg227",
        "oom_timestamps": [],
        "crash_timestamps": [
          "2025-12-12T06:05:38Z"
        ],
        "sources": [
          "events"
        ],
        "description_file": "/private/tmp/kflux-prd-es01/clusters-611e937f-5577-47db-a301-cd73c98d6e99__redhat-operators-catalog-6b8bd8fc8f-mg227__20251212T065144Z__desc.txt",
        "pod_log_file": "/private/tmp/kflux-prd-es01/clusters-611e937f-5577-47db-a301-cd73c98d6e99__redhat-operators-catalog-6b8bd8fc8f-mg227__20251212T065144Z__log.txt"
      }
    },
    "clusters-dff42627-b5e9-46f1-b161-bdf5fc302c57": {
      "catalog-operator-5948b97f7d-85bzm": {
        "pod": "catalog-operator-5948b97f7d-85bzm",
        "oom_timestamps": [],
        "crash_timestamps": [
          "2025-12-12T06:44:59Z"
        ],
        "sources": [
          "events"
        ],
        "description_file": "/private/tmp/kflux-prd-es01/clusters-dff42627-b5e9-46f1-b161-bdf5fc302c57__catalog-operator-5948b97f7d-85bzm__20251212T065148Z__desc.txt",
        "pod_log_file": "/private/tmp/kflux-prd-es01/clusters-dff42627-b5e9-46f1-b161-bdf5fc302c57__catalog-operator-5948b97f7d-85bzm__20251212T065148Z__log.txt"
      },
      "certified-operators-catalog-74dbb8f6c5-tb6nz": {
        "pod": "certified-operators-catalog-74dbb8f6c5-tb6nz",
        "oom_timestamps": [],
        "crash_timestamps": [
          "2025-12-12T06:44:51Z"
        ],
        "sources": [
          "events"
        ],
        "description_file": "/private/tmp/kflux-prd-es01/clusters-dff42627-b5e9-46f1-b161-bdf5fc302c57__certified-operators-catalog-74dbb8f6c5-tb6nz__20251212T065156Z__desc.txt",
        "pod_log_file": "/private/tmp/kflux-prd-es01/clusters-dff42627-b5e9-46f1-b161-bdf5fc302c57__certified-operators-catalog-74dbb8f6c5-tb6nz__20251212T065156Z__log.txt"
      },
      "community-operators-catalog-575fbfb7c5-9qr4p": {
        "pod": "community-operators-catalog-575fbfb7c5-9qr4p",
        "oom_timestamps": [],
        "crash_timestamps": [
          "2025-12-12T06:44:51Z"
        ],
        "sources": [
          "events"
        ],
        "description_file": "/private/tmp/kflux-prd-es01/clusters-dff42627-b5e9-46f1-b161-bdf5fc302c57__community-operators-catalog-575fbfb7c5-9qr4p__20251212T065158Z__desc.txt",
        "pod_log_file": "/private/tmp/kflux-prd-es01/clusters-dff42627-b5e9-46f1-b161-bdf5fc302c57__community-operators-catalog-575fbfb7c5-9qr4p__20251212T065158Z__log.txt"
      },
      "redhat-marketplace-catalog-5fff54d476-4hppf": {
        "pod": "redhat-marketplace-catalog-5fff54d476-4hppf",
        "oom_timestamps": [],
        "crash_timestamps": [
          "2025-12-12T06:44:51Z"
        ],
        "sources": [
          "events"
        ],
        "description_file": "/private/tmp/kflux-prd-es01/clusters-dff42627-b5e9-46f1-b161-bdf5fc302c57__redhat-marketplace-catalog-5fff54d476-4hppf__20251212T065159Z__desc.txt",
        "pod_log_file": "/private/tmp/kflux-prd-es01/clusters-dff42627-b5e9-46f1-b161-bdf5fc302c57__redhat-marketplace-catalog-5fff54d476-4hppf__20251212T065159Z__log.txt"
      },
      "redhat-operators-catalog-7cd6f8cddc-2bk5k": {
        "pod": "redhat-operators-catalog-7cd6f8cddc-2bk5k",
        "oom_timestamps": [],
        "crash_timestamps": [
          "2025-12-12T06:44:51Z"
        ],
        "sources": [
          "events"
        ],
        "description_file": "/private/tmp/kflux-prd-es01/clusters-dff42627-b5e9-46f1-b161-bdf5fc302c57__redhat-operators-catalog-7cd6f8cddc-2bk5k__20251212T065200Z__desc.txt",
        "pod_log_file": "/private/tmp/kflux-prd-es01/clusters-dff42627-b5e9-46f1-b161-bdf5fc302c57__redhat-operators-catalog-7cd6f8cddc-2bk5k__20251212T065200Z__log.txt"
      }
    },
    "clusters-05444e73-dd68-48b6-899e-0a807a4eb1b3": {
      "catalog-operator-74999f6f44-wv46s": {
        "pod": "catalog-operator-74999f6f44-wv46s",
        "oom_timestamps": [],
        "crash_timestamps": [
          "2025-12-12T06:35:38Z"
        ],
        "sources": [
          "events"
        ],
        "description_file": "/private/tmp/kflux-prd-es01/clusters-05444e73-dd68-48b6-899e-0a807a4eb1b3__catalog-operator-74999f6f44-wv46s__20251212T065201Z__desc.txt",
        "pod_log_file": "/private/tmp/kflux-prd-es01/clusters-05444e73-dd68-48b6-899e-0a807a4eb1b3__catalog-operator-74999f6f44-wv46s__20251212T065201Z__log.txt"
      },
      "certified-operators-catalog-d5b7b896b-q5s2r": {
        "pod": "certified-operators-catalog-d5b7b896b-q5s2r",
        "oom_timestamps": [],
        "crash_timestamps": [
          "2025-12-12T06:35:28Z"
        ],
        "sources": [
          "events"
        ],
        "description_file": "/private/tmp/kflux-prd-es01/clusters-05444e73-dd68-48b6-899e-0a807a4eb1b3__certified-operators-catalog-d5b7b896b-q5s2r__20251212T065201Z__desc.txt",
        "pod_log_file": "/private/tmp/kflux-prd-es01/clusters-05444e73-dd68-48b6-899e-0a807a4eb1b3__certified-operators-catalog-d5b7b896b-q5s2r__20251212T065201Z__log.txt"
      },
      "community-operators-catalog-66f496b886-v6bk2": {
        "pod": "community-operators-catalog-66f496b886-v6bk2",
        "oom_timestamps": [],
        "crash_timestamps": [
          "2025-12-12T06:35:28Z"
        ],
        "sources": [
          "events"
        ],
        "description_file": "/private/tmp/kflux-prd-es01/clusters-05444e73-dd68-48b6-899e-0a807a4eb1b3__community-operators-catalog-66f496b886-v6bk2__20251212T065203Z__desc.txt",
        "pod_log_file": "/private/tmp/kflux-prd-es01/clusters-05444e73-dd68-48b6-899e-0a807a4eb1b3__community-operators-catalog-66f496b886-v6bk2__20251212T065203Z__log.txt"
      },
      "redhat-marketplace-catalog-db87499f5-w9qgc": {
        "pod": "redhat-marketplace-catalog-db87499f5-w9qgc",
        "oom_timestamps": [],
        "crash_timestamps": [
          "2025-12-12T06:35:28Z"
        ],
        "sources": [
          "events"
        ],
        "description_file": "/private/tmp/kflux-prd-es01/clusters-05444e73-dd68-48b6-899e-0a807a4eb1b3__redhat-marketplace-catalog-db87499f5-w9qgc__20251212T065203Z__desc.txt",
        "pod_log_file": "/private/tmp/kflux-prd-es01/clusters-05444e73-dd68-48b6-899e-0a807a4eb1b3__redhat-marketplace-catalog-db87499f5-w9qgc__20251212T065203Z__log.txt"
      },
      "redhat-operators-catalog-7fdf966868-lld94": {
        "pod": "redhat-operators-catalog-7fdf966868-lld94",
        "oom_timestamps": [],
        "crash_timestamps": [
          "2025-12-12T06:35:28Z"
        ],
        "sources": [
          "events"
        ],
        "description_file": "/private/tmp/kflux-prd-es01/clusters-05444e73-dd68-48b6-899e-0a807a4eb1b3__redhat-operators-catalog-7fdf966868-lld94__20251212T065204Z__desc.txt",
        "pod_log_file": "/private/tmp/kflux-prd-es01/clusters-05444e73-dd68-48b6-899e-0a807a4eb1b3__redhat-operators-catalog-7fdf966868-lld94__20251212T065204Z__log.txt"
      }
    },
    "clusters-2ecdf824-659a-43b4-8432-507e3398f8d0": {
      "catalog-operator-68f979975b-ls94l": {
        "pod": "catalog-operator-68f979975b-ls94l",
        "oom_timestamps": [],
        "crash_timestamps": [
          "2025-12-12T06:05:58Z"
        ],
        "sources": [
          "events"
        ],
        "description_file": "/private/tmp/kflux-prd-es01/clusters-2ecdf824-659a-43b4-8432-507e3398f8d0__catalog-operator-68f979975b-ls94l__20251212T065205Z__desc.txt",
        "pod_log_file": "/private/tmp/kflux-prd-es01/clusters-2ecdf824-659a-43b4-8432-507e3398f8d0__catalog-operator-68f979975b-ls94l__20251212T065205Z__log.txt"
      },
      "certified-operators-catalog-79795d58-87w4n": {
        "pod": "certified-operators-catalog-79795d58-87w4n",
        "oom_timestamps": [],
        "crash_timestamps": [
          "2025-12-12T06:05:40Z"
        ],
        "sources": [
          "events"
        ],
        "description_file": "/private/tmp/kflux-prd-es01/clusters-2ecdf824-659a-43b4-8432-507e3398f8d0__certified-operators-catalog-79795d58-87w4n__20251212T065206Z__desc.txt",
        "pod_log_file": "/private/tmp/kflux-prd-es01/clusters-2ecdf824-659a-43b4-8432-507e3398f8d0__certified-operators-catalog-79795d58-87w4n__20251212T065206Z__log.txt"
      },
      "community-operators-catalog-798596ff98-cjvxg": {
        "pod": "community-operators-catalog-798596ff98-cjvxg",
        "oom_timestamps": [],
        "crash_timestamps": [
          "2025-12-12T06:05:40Z"
        ],
        "sources": [
          "events"
        ],
        "description_file": "/private/tmp/kflux-prd-es01/clusters-2ecdf824-659a-43b4-8432-507e3398f8d0__community-operators-catalog-798596ff98-cjvxg__20251212T065206Z__desc.txt",
        "pod_log_file": "/private/tmp/kflux-prd-es01/clusters-2ecdf824-659a-43b4-8432-507e3398f8d0__community-operators-catalog-798596ff98-cjvxg__20251212T065206Z__log.txt"
      },
      "redhat-marketplace-catalog-5c7bc7b49f-cs8sr": {
        "pod": "redhat-marketplace-catalog-5c7bc7b49f-cs8sr",
        "oom_timestamps": [],
        "crash_timestamps": [
          "2025-12-12T06:05:40Z"
        ],
        "sources": [
          "events"
        ],
        "description_file": "/private/tmp/kflux-prd-es01/clusters-2ecdf824-659a-43b4-8432-507e3398f8d0__redhat-marketplace-catalog-5c7bc7b49f-cs8sr__20251212T065207Z__desc.txt",
        "pod_log_file": "/private/tmp/kflux-prd-es01/clusters-2ecdf824-659a-43b4-8432-507e3398f8d0__redhat-marketplace-catalog-5c7bc7b49f-cs8sr__20251212T065207Z__log.txt"
      },
      "redhat-operators-catalog-7f6767649b-4wr8q": {
        "pod": "redhat-operators-catalog-7f6767649b-4wr8q",
        "oom_timestamps": [],
        "crash_timestamps": [
          "2025-12-12T06:05:40Z"
        ],
        "sources": [
          "events"
        ],
        "description_file": "/private/tmp/kflux-prd-es01/clusters-2ecdf824-659a-43b4-8432-507e3398f8d0__redhat-operators-catalog-7f6767649b-4wr8q__20251212T065215Z__desc.txt",
        "pod_log_file": "/private/tmp/kflux-prd-es01/clusters-2ecdf824-659a-43b4-8432-507e3398f8d0__redhat-operators-catalog-7f6767649b-4wr8q__20251212T065215Z__log.txt"
      }
    }
  },
  "kflux-osp-p01": {},
  "kflux-prd-rh02": {
    "pulp-access-controller": {
      "pulp-access-operator-5dbc87f4-9964v": {
        "pod": "pulp-access-operator-5dbc87f4-9964v",
        "oom_timestamps": [],
        "crash_timestamps": [
          "2025-12-12T06:49:17Z"
        ],
        "sources": [
          "events"
        ],
        "description_file": "/private/tmp/kflux-prd-rh02/pulp-access-controller__pulp-access-operator-5dbc87f4-9964v__20251212T065224Z__desc.txt",
        "pod_log_file": "/private/tmp/kflux-prd-rh02/pulp-access-controller__pulp-access-operator-5dbc87f4-9964v__20251212T065224Z__log.txt"
      }
    }
  },
  "kflux-ocp-p01": {},
  "kflux-stg-es01": {},
  "kflux-rhel-p01": {},
  "kflux-prd-rh03": {},
  "stone-prd-rh01": {},
  "stone-prod-p01": {},
  "stone-stage-p01": {},
  "stone-stg-rh01": {
    "pulp-access-controller": {
      "pulp-access-operator-5dbc87f4-lb8jf": {
        "pod": "pulp-access-operator-5dbc87f4-lb8jf",
        "oom_timestamps": [],
        "crash_timestamps": [
          "2025-12-12T07:16:09Z"
        ],
        "sources": [
          "events"
        ],
        "description_file": "/private/tmp/stone-stg-rh01/pulp-access-controller__pulp-access-operator-5dbc87f4-lb8jf__20251212T071736Z__desc.txt",
        "pod_log_file": "/private/tmp/stone-stg-rh01/pulp-access-controller__pulp-access-operator-5dbc87f4-lb8jf__20251212T071736Z__log.txt"
      }
    }
  },
  "stone-prod-p02": {
    "pulp-access-controller": {
      "pulp-access-operator-5dbc87f4-qdmv6": {
        "pod": "pulp-access-operator-5dbc87f4-qdmv6",
        "oom_timestamps": [],
        "crash_timestamps": [
          "2025-12-12T07:18:05Z"
        ],
        "sources": [
          "events"
        ],
        "description_file": "/private/tmp/stone-prod-p02/pulp-access-controller__pulp-access-operator-5dbc87f4-qdmv6__20251212T072016Z__desc.txt",
        "pod_log_file": "/private/tmp/stone-prod-p02/pulp-access-controller__pulp-access-operator-5dbc87f4-qdmv6__20251212T072016Z__log.txt"
      }
    },
    "rhoai-tenant": {
      "mlflow-poc-on-pull-request-kks5p-sast-coverity-check-pod": {
        "pod": "mlflow-poc-on-pull-request-kks5p-sast-coverity-check-pod",
        "oom_timestamps": [],
        "crash_timestamps": [
          "2025-12-12T04:54:29Z"
        ],
        "sources": [
          "events"
        ],
        "description_file": "/private/tmp/stone-prod-p02/rhoai-tenant__mlflow-poc-on-pull-request-kks5p-sast-coverity-check-pod__20251212T072108Z__desc.txt",
        "pod_log_file": "/private/tmp/stone-prod-p02/rhoai-tenant__mlflow-poc-on-pull-request-kks5p-sast-coverity-check-pod__20251212T072108Z__log.txt"
      },
      "mlflow-poc-on-pull-request-s4f77-sast-coverity-check-pod": {
        "pod": "mlflow-poc-on-pull-request-s4f77-sast-coverity-check-pod",
        "oom_timestamps": [],
        "crash_timestamps": [
          "2025-12-12T04:53:18Z",
          "2025-12-12T04:53:19Z"
        ],
        "sources": [
          "events"
        ],
        "description_file": "/private/tmp/stone-prod-p02/rhoai-tenant__mlflow-poc-on-pull-request-s4f77-sast-coverity-check-pod__20251212T072109Z__desc.txt",
        "pod_log_file": "/private/tmp/stone-prod-p02/rhoai-tenant__mlflow-poc-on-pull-request-s4f77-sast-coverity-check-pod__20251212T072109Z__log.txt"
      },
      "rhoai-health-on-pull-request-pdbgb-sast-coverity-check-pod": {
        "pod": "rhoai-health-on-pull-request-pdbgb-sast-coverity-check-pod",
        "oom_timestamps": [],
        "crash_timestamps": [
          "2025-12-12T05:09:33Z"
        ],
        "sources": [
          "events"
        ],
        "description_file": "/private/tmp/stone-prod-p02/rhoai-tenant__rhoai-health-on-pull-request-pdbgb-sast-coverity-check-pod__20251212T072110Z__desc.txt",
        "pod_log_file": "/private/tmp/stone-prod-p02/rhoai-tenant__rhoai-health-on-pull-request-pdbgb-sast-coverity-check-pod__20251212T072110Z__log.txt"
      }
    }
  }
```

We have been using a prior version (shell based) of this tool to raise Jiras on various components so far. E.g:
1. https://issues.redhat.com/browse/RELEASE-1916
2. https://issues.redhat.com/browse/KONFLUX-10806
3. https://issues.redhat.com/browse/KONFLUX-10918
4. https://issues.redhat.com/browse/KONFLUX-10955
5. https://issues.redhat.com/browse/KONFLUX-10957
6. https://issues.redhat.com/browse/KONFLUX-10969
7. https://issues.redhat.com/browse/KONFLUX-11032
8. https://issues.redhat.com/browse/KONFLUX-11055
9. https://issues.redhat.com/browse/KONFLUX-11056
10. https://issues.redhat.com/browse/KONFLUX-11068
11. https://issues.redhat.com/browse/KONFLUX-11178
12. https://issues.redhat.com/browse/KONFLUX-11179
13. https://issues.redhat.com/browse/KONFLUX-11365

Cc: @jhutar @psuriset 