### PR TITLE
Fix percentile accuracy by moving memory stats computation into PromQL and harden batching

### DIFF
--- a/task-mem-usage-scripts/README.md
+++ b/task-mem-usage-scripts/README.md
@@ -1,13 +1,18 @@
-Scripts for extracting Memory Usage
-===================================
+Scripts for extracting Memory and CPU Usage Metrics
+====================================================
 
-This directory contains scripts for extracting memory usage metrics (Max, P95, P90, Median) for each `task` and `step` executed inside Konflux clusters. These scripts were created while addressing: https://issues.redhat.com/browse/KONFLUX-6712.
+This directory contains scripts for extracting memory and CPU usage metrics (Max, P95, P90, Median) for each `task` and `step` executed inside Konflux clusters. These scripts were created while addressing: https://issues.redhat.com/browse/KONFLUX-6712.
 
 The workflow supports:
-- Multi-cluster execution
-- CSV / JSON / Colorized text output
-- Per-pod memory usage attribution
-- Automatic retrieval of Namespace, Component, Application (where available)
+- **Multi-cluster execution** - Automatically iterates over all configured clusters
+- **Memory metrics** - Max, P95, P90, and Median memory usage per task/step
+- **CPU metrics** - Max, P95, P90, and Median CPU usage per task/step (NEW)
+- **Optimized batching** - Handles unlimited pods efficiently using intelligent batching (NEW)
+- **Long time ranges** - Supports 1 day to 30+ days with adaptive query optimization (NEW)
+- **Task-scoped queries** - Ensures metrics are only from pods belonging to the specified task (NEW)
+- **CSV / JSON / Colorized text output** - Multiple output formats
+- **Per-pod attribution** - Identifies the specific pod with max memory and max CPU usage
+- **Automatic metadata retrieval** - Namespace, Component, Application (where available)
 
 Architecture Overview (ASCII Diagram)
 ===================================
@@ -31,8 +36,10 @@ Architecture Overview (ASCII Diagram)
           │──────────────────────────────────────────────────────────────────────────│
           │ • Reads task list (task_name + step_name)                                │
           │ • For each <task, step> pair:                                            │
-          │       - Calls Python script to list pods                                 │
-          │       - Loops over pods and calls container-metric collector             │
+          │       - Calls Python script to list pods (filtered by task label)       │
+          │       - Processes pods in batches (50 pods per batch) to avoid limits   │
+          │       - Queries memory and CPU metrics for each batch                    │
+          │       - Aggregates results across all batches                            │
           │ • Passes through OUTPUT_MODE (human, json, csv)                          │
           └──────────────────────────────┬───────────────────────────────────────────┘
                                          │
@@ -48,28 +55,35 @@ Architecture Overview (ASCII Diagram)
                                                 │
                                                 ▼
              ┌─────────────────────────────────────────────────────────────────────┐
-             │ list_container_mem_usage_for_a_particular_pod.py                    │
+             │ query_prometheus_range.py (optimized)                               │
              │─────────────────────────────────────────────────────────────────────│
-             │ • Accepts pod + container name(s)                                   │
-             │ • Sends HTTP POST requests to Prometheus API                        │
-             │ • Executes queries:                                                 │
-             │        - container_memory_max_usage_bytes                           │
-             │        - container_memory_working_set_bytes                         │
-             │        - container_memory_rss                                       │
-             │        - custom percentile aggregations                             │
-             │ • Returns:                                                          │
-             │        → MAX                                                        │
-             │        → P95                                                        │
-             │        → P90                                                        │
-             │        → MEDIAN                                                     │
+             │ • Accepts PromQL query, start time, end time                        │
+             │ • Uses adaptive step sizing based on time range:                     │
+             │        - ≤1 day: 30s step                                           │
+             │        - ≤7 days: 5m step                                           │
+             │        - ≤30 days: 15m step                                         │
+             │        - >30 days: 1h step                                           │
+             │ • Sends HTTP requests to Prometheus API                             │
+             │ • Executes queries for:                                              │
+             │        - container_memory_max_usage_bytes (peak memory)              │
+             │        - container_memory_working_set_bytes (for percentiles)       │
+             │        - container_cpu_usage_seconds_total (with rate calculation)  │
+             │ • Returns time series data for aggregation                           │
              └──────────────────────────────┬──────────────────────────────────────┘
                                             │
                                             ▼
                      ┌──────────────────────────────────────────────────────────┐
                      │             Aggregators in wrapper_for_promql.sh         │
                      │──────────────────────────────────────────────────────────│
-                     │ • Merges:                                                │
-                     │        cluster × namespace × task × step × pod × result  │
+                     │ • Processes pods in batches (50 per batch)              │
+                     │ • For each batch:                                        │
+                     │        - Queries memory max, p95, p90, median            │
+                     │        - Queries CPU max, p95, p90, median              │
+                     │        - Validates returned pods belong to task         │
+                     │ • Aggregates across all batches:                         │
+                     │        - Finds global max memory pod and value           │
+                     │        - Finds global max CPU pod and value              │
+                     │        - Calculates accurate percentiles across all pods │
                      │ • Creates consolidated records                           │
                      │ • Delegates final formatting to output backends          │
                      └──────────────────────────────┬───────────────────────────┘
@@ -101,7 +115,17 @@ Example:
 
     ./wrapper_for_promql_for_all_clusters.sh 7
 
-The PromQL range window and sampling delta adjust automatically.
+The PromQL range window and sampling delta adjust automatically based on the time range:
+- **1 day**: 30-second resolution for fine-grained analysis
+- **7 days**: 5-minute resolution (optimized for Prometheus limits)
+- **30 days**: 15-minute resolution
+- **30+ days**: 1-hour resolution
+
+**Performance Optimizations:**
+- **Intelligent Batching**: Pods are processed in batches of 50 to avoid URL length and query complexity limits
+- **Task-Scoped Queries**: All metrics are validated to ensure they only come from pods belonging to the specified task
+- **Adaptive Step Sizing**: Query resolution automatically adjusts to stay within Prometheus data point limits
+- **Efficient Aggregation**: Percentiles are calculated accurately across all pods, not per-batch
 
 Python Virtual Environment
 ===================================
@@ -123,11 +147,30 @@ Example:
 
     ./wrapper_for_promql_for_all_clusters.sh 1 --csv
 
+CSV Output Format
+===================================
+The CSV output includes both memory and CPU metrics with separate pod attribution:
+
+```
+"cluster","task","step","pod_max_memory","pod_namespace_mem","component","application","mem_max_mb","mem_p95_mb","mem_p90_mb","mem_median_mb","pod_max_cpu","pod_namespace_cpu","cpu_max","cpu_p95","cpu_p90","cpu_median"
+```
+
+**Column Descriptions:**
+- `pod_max_memory` - Pod name with the highest memory usage
+- `pod_namespace_mem` - Namespace of the pod with max memory
+- `component` - Component name for the max memory pod (if available)
+- `application` - Application name for the max memory pod (if available)
+- `mem_max_mb` - Maximum memory usage in MB
+- `mem_p95_mb`, `mem_p90_mb`, `mem_median_mb` - Memory percentiles in MB
+- `pod_max_cpu` - Pod name with the highest CPU usage
+- `pod_namespace_cpu` - Namespace of the pod with max CPU
+- `cpu_max`, `cpu_p95`, `cpu_p90`, `cpu_median` - CPU metrics in millicores (e.g., "3569m")
+
 CSV Output Example
 ===================================
 ```
-"cluster","task","step","max_mem_mb","pod","namespace","component","application","p95_mb","p90_mb","median_mb"
-"kflux-prd-rh02","buildah","step-build","8192","crc-binary-on-pull-request-6kgk9-build-container-pod","crc-tenant","N/A","N/A","0","0","0"
+"cluster","task","step","pod_max_memory","pod_namespace_mem","component","application","mem_max_mb","mem_p95_mb","mem_p90_mb","mem_median_mb","pod_max_cpu","pod_namespace_cpu","cpu_max","cpu_p95","cpu_p90","cpu_median"
+"stone-prd-rh01","buildah","step-build","maestro-on-pull-request-wtpkk-build-container-pod","maestro-rhtap-tenant","N/A","N/A","8192","8191","8190","8183","operator-on-pull-request-45m69-build-container-pod","vp-operator-release-tenant","3569m","3569m","3569m","3569m"
 "kflux-prd-rh02","buildah","step-push","175","rhobs-observato8863c7ac646c45ff10fb9046c502710ae37ef8bf870e-pod","rhobs-mco-tenant","N/A","N/A","0","0","0"
 "kflux-prd-rh02","buildah","step-sbom-syft-generate","10","rhobs-observatoee6e952803459989d848471898dd7a5ad76331c37d9f-pod","rhobs-mco-tenant","N/A","N/A","0","0","0"
 "kflux-prd-rh02","buildah","step-prepare-sboms","10","crc-binary-on-pull-request-6kgk9-build-container-pod","crc-tenant","N/A","N/A","0","0","0"

--- a/task-mem-usage-scripts/analyze_resource_limits.py
+++ b/task-mem-usage-scripts/analyze_resource_limits.py
@@ -1,0 +1,488 @@
+#!/usr/bin/env python3
+"""
+Analyze resource consumption data and provide recommendations for resource limits.
+
+Usage:
+    # From piped input:
+    ./wrapper_for_promql_for_all_clusters.sh 7 --csv | ./analyze_resource_limits.py
+
+    # From YAML file (auto-runs data collection):
+    ./analyze_resource_limits.py --file /path/to/buildah.yaml
+    ./analyze_resource_limits.py --file https://github.com/.../buildah.yaml
+
+    # Update YAML file with recommendations:
+    ./analyze_resource_limits.py --file /path/to/buildah.yaml --update
+"""
+
+import argparse
+import csv
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.parse
+from collections import defaultdict
+from pathlib import Path
+
+try:
+    import requests
+    import yaml
+except ImportError as e:
+    print(f"Error: Missing required library. Install with: pip install requests pyyaml", file=sys.stderr)
+    sys.exit(1)
+
+
+def convert_github_url_to_raw(url):
+    """Convert GitHub blob URL to raw content URL."""
+    # Convert blob URL to raw URL
+    # https://github.com/user/repo/blob/branch/path -> https://raw.githubusercontent.com/user/repo/branch/path
+    pattern = r'https://github\.com/([^/]+)/([^/]+)/blob/([^/]+)/(.+)'
+    match = re.match(pattern, url)
+    if match:
+        user, repo, branch, path = match.groups()
+        return f"https://raw.githubusercontent.com/{user}/{repo}/{branch}/{path}"
+    return url
+
+
+def fetch_yaml_content(file_path_or_url):
+    """Fetch YAML content from file path or URL."""
+    if file_path_or_url.startswith('http://') or file_path_or_url.startswith('https://'):
+        url = convert_github_url_to_raw(file_path_or_url)
+        try:
+            response = requests.get(url, timeout=30)
+            response.raise_for_status()
+            return yaml.safe_load(response.text), url
+        except requests.RequestException as e:
+            print(f"Error fetching URL {url}: {e}", file=sys.stderr)
+            sys.exit(1)
+    else:
+        path = Path(file_path_or_url)
+        if not path.exists():
+            print(f"Error: File not found: {file_path_or_url}", file=sys.stderr)
+            sys.exit(1)
+        with open(path, 'r') as f:
+            return yaml.safe_load(f), str(path.absolute())
+
+
+def extract_task_info(yaml_content):
+    """Extract task name and step names from Tekton Task YAML."""
+    task_name = yaml_content.get('metadata', {}).get('name', '')
+    steps = []
+    
+    # Extract step names from spec.steps
+    for step in yaml_content.get('spec', {}).get('steps', []):
+        step_name = step.get('name', '')
+        if step_name:
+            steps.append(step_name)
+    
+    # Also check stepTemplate for default resources
+    step_template = yaml_content.get('spec', {}).get('stepTemplate', {})
+    default_resources = step_template.get('computeResources', {})
+    
+    return task_name, steps, default_resources
+
+
+def run_data_collection(task_name, steps, days=7):
+    """Run the wrapper script to collect data."""
+    script_path = Path(__file__).parent / 'wrapper_for_promql_for_all_clusters.sh'
+    if not script_path.exists():
+        print(f"Error: wrapper script not found: {script_path}", file=sys.stderr)
+        sys.exit(1)
+    
+    # Create a temporary wrapper that sets TASK_NAME and STEPS
+    temp_wrapper = script_path.parent / '.temp_wrapper.sh'
+    try:
+        with open(script_path, 'r') as f:
+            wrapper_content = f.read()
+        
+        # Replace hardcoded TASK_NAME and STEPS
+        # Steps in CSV are "step-{name}", so ensure we use that format
+        wrapper_content = re.sub(
+            r'TASK_NAME="[^"]*"',
+            f'TASK_NAME="{task_name}"',
+            wrapper_content
+        )
+        # Convert step names to "step-{name}" format for the wrapper
+        steps_str = ' '.join(f'step-{s}' if not s.startswith('step-') else s for s in steps)
+        wrapper_content = re.sub(
+            r'STEPS="[^"]*"',
+            f'STEPS="{steps_str}"',
+            wrapper_content
+        )
+        
+        with open(temp_wrapper, 'w') as f:
+            f.write(wrapper_content)
+        os.chmod(temp_wrapper, 0o755)
+        
+        # Run the wrapper
+        print(f"Collecting data for task '{task_name}' with steps: {', '.join(steps)}", file=sys.stderr)
+        print(f"Running: {temp_wrapper} {days} --csv", file=sys.stderr)
+        
+        result = subprocess.run(
+            [str(temp_wrapper), str(days), '--csv'],
+            capture_output=True,
+            text=True,
+            cwd=script_path.parent
+        )
+        
+        if result.returncode != 0:
+            print(f"Error running wrapper script:", file=sys.stderr)
+            print(result.stderr, file=sys.stderr)
+            sys.exit(1)
+        
+        return result.stdout
+    finally:
+        if temp_wrapper.exists():
+            temp_wrapper.unlink()
+
+
+def parse_csv_data(csv_text):
+    """Parse CSV data from the wrapper script output."""
+    data = []
+    lines = [line for line in csv_text.strip().split('\n') if line.strip()]
+    if not lines:
+        return data
+    
+    reader = csv.DictReader(lines)
+    for row in reader:
+        # Clean up keys (remove spaces and quotes)
+        cleaned_row = {k.strip().strip('"'): v.strip().strip('"') for k, v in row.items()}
+        data.append(cleaned_row)
+    return data
+
+
+def round_memory_to_standard(mb):
+    """Round memory to standard Kubernetes values.
+    
+    For values < 1Gi: round to nearest power of 2 (32Mi, 64Mi, 128Mi, 256Mi, 512Mi)
+    For values >= 1Gi: round to whole Gi values (1Gi, 2Gi, 3Gi, etc.)
+    
+    Rounds to nearest, but ensures we don't go below the recommended value.
+    """
+    mb = float(mb)
+    
+    if mb < 1024:
+        # Round to nearest power of 2: 32, 64, 128, 256, 512
+        # Thresholds are midpoints between powers of 2
+        if mb <= 48:
+            rounded = 32
+        elif mb <= 96:
+            rounded = 64
+        elif mb <= 192:
+            rounded = 128
+        elif mb <= 384:
+            rounded = 256
+        elif mb <= 768:
+            rounded = 512
+        else:
+            # > 768Mi, round up to next Gi
+            return 1024
+        
+        # Ensure we don't go below the recommended value
+        if rounded < mb:
+            # Round up to next power of 2
+            if rounded == 32:
+                rounded = 64
+            elif rounded == 64:
+                rounded = 128
+            elif rounded == 128:
+                rounded = 256
+            elif rounded == 256:
+                rounded = 512
+            elif rounded == 512:
+                rounded = 1024
+        
+        return rounded
+    else:
+        # Round to nearest whole Gi, but round up if fractional
+        gi = mb / 1024.0
+        rounded_gi = round(gi)
+        # If rounding down would go below original, round up instead
+        if rounded_gi * 1024 < mb:
+            rounded_gi += 1
+        return rounded_gi * 1024
+
+
+def mb_to_kubernetes(mb):
+    """Convert MB to Kubernetes memory format with standard rounding."""
+    mb = float(mb)
+    rounded_mb = round_memory_to_standard(mb)
+    
+    if rounded_mb < 1024:
+        return f"{int(rounded_mb)}Mi"
+    else:
+        gi = rounded_mb / 1024.0
+        # Should always be whole number after rounding
+        return f"{int(gi)}Gi"
+
+
+def round_cpu_to_standard(cores):
+    """Round CPU to nearest millicore value.
+    
+    Always rounds to nearest millicore (e.g., 5.1 cores = 5100m).
+    Rounds up to ensure we don't go below the recommended value.
+    """
+    cores = float(cores)
+    millicores = cores * 1000
+    
+    # Round up to nearest millicore
+    rounded_m = int(millicores) + (1 if (millicores % 1) > 0 else 0)
+    return rounded_m / 1000.0
+
+
+def cores_to_kubernetes(cores):
+    """Convert cores to Kubernetes CPU format, always in millicores."""
+    cores = float(cores)
+    rounded_cores = round_cpu_to_standard(cores)
+    
+    # Always return as millicores
+    millicores = int(rounded_cores * 1000)
+    return f"{millicores}m"
+
+
+def parse_cpu_value(cpu_str):
+    """Parse CPU value from format like '3569m' or '4.5'."""
+    if not cpu_str or cpu_str == '0m' or cpu_str == '0':
+        return 0.0
+    if cpu_str.endswith('m'):
+        return float(cpu_str[:-1]) / 1000.0
+    return float(cpu_str)
+
+
+def analyze_step_data(step_name, step_rows, margin_pct=10):
+    """Analyze data for a specific step and return recommendations."""
+    if not step_rows:
+        return None
+    
+    # Extract memory values
+    mem_max_values = [float(r['mem_max_mb']) for r in step_rows if r.get('mem_max_mb') and r['mem_max_mb'] not in ('0', '', 'N/A')]
+    mem_p95_values = [float(r['mem_p95_mb']) for r in step_rows if r.get('mem_p95_mb') and r['mem_p95_mb'] not in ('0', '', 'N/A')]
+    mem_p90_values = [float(r['mem_p90_mb']) for r in step_rows if r.get('mem_p90_mb') and r['mem_p90_mb'] not in ('0', '', 'N/A')]
+    mem_median_values = [float(r['mem_median_mb']) for r in step_rows if r.get('mem_median_mb') and r['mem_median_mb'] not in ('0', '', 'N/A')]
+    
+    # Extract CPU values
+    cpu_max_values = [parse_cpu_value(r.get('cpu_max', '0m')) for r in step_rows if r.get('cpu_max')]
+    cpu_p95_values = [parse_cpu_value(r.get('cpu_p95', '0m')) for r in step_rows if r.get('cpu_p95')]
+    cpu_p90_values = [parse_cpu_value(r.get('cpu_p90', '0m')) for r in step_rows if r.get('cpu_p90')]
+    cpu_median_values = [parse_cpu_value(r.get('cpu_median', '0m')) for r in step_rows if r.get('cpu_median')]
+    
+    if not mem_max_values:
+        return None
+    
+    # Calculate max across all clusters
+    mem_max_max = max(mem_max_values)
+    mem_p95_max = max(mem_p95_values) if mem_p95_values else 0
+    mem_p90_max = max(mem_p90_values) if mem_p90_values else 0
+    mem_median_max = max(mem_median_values) if mem_median_values else 0
+    
+    cpu_max_max = max(cpu_max_values) if cpu_max_values else 0
+    cpu_p95_max = max(cpu_p95_values) if cpu_p95_values else 0
+    cpu_p90_max = max(cpu_p90_values) if cpu_p90_values else 0
+    cpu_median_max = max(cpu_median_values) if cpu_median_values else 0
+    
+    # Calculate recommendations: P95 + margin, but don't exceed max observed
+    mem_recommended = min(mem_max_max, int(mem_p95_max * (1 + margin_pct / 100))) if mem_p95_max > 0 else mem_max_max
+    if cpu_p95_max > 0:
+        cpu_recommended = min(cpu_max_max * 1.1, cpu_p95_max * (1 + margin_pct / 100))
+    else:
+        cpu_recommended = cpu_max_max if cpu_max_max > 0 else 0
+    
+    # Count coverage
+    mem_coverage = len([x for x in mem_max_values if x <= mem_recommended])
+    cpu_coverage = len([x for x in cpu_max_values if x <= cpu_recommended]) if cpu_max_values else 0
+    
+    return {
+        'step_name': step_name,
+        'mem_recommended_mb': mem_recommended,
+        'mem_recommended_k8s': mb_to_kubernetes(mem_recommended),
+        'cpu_recommended_cores': cpu_recommended,
+        'cpu_recommended_k8s': cores_to_kubernetes(cpu_recommended),
+        'mem_max_max': mem_max_max,
+        'mem_p95_max': mem_p95_max,
+        'cpu_max_max': cpu_max_max,
+        'cpu_p95_max': cpu_p95_max,
+        'mem_coverage': mem_coverage,
+        'mem_total': len(mem_max_values),
+        'cpu_coverage': cpu_coverage,
+        'cpu_total': len(cpu_max_values) if cpu_max_values else 0,
+    }
+
+
+def print_analysis(recommendations, margin_pct):
+    """Print analysis results."""
+    print("=" * 80)
+    print(f"RESOURCE LIMIT RECOMMENDATIONS (P95 + {margin_pct}% Safety Margin)")
+    print("=" * 80)
+    print()
+    
+    for rec in recommendations:
+        if rec is None:
+            continue
+        
+        print(f"Step: {rec['step_name']}")
+        print("-" * 80)
+        print(f"  Memory: {rec['mem_recommended_k8s']}")
+        print(f"    - Max observed: {mb_to_kubernetes(rec['mem_max_max'])}")
+        print(f"    - P95 max: {mb_to_kubernetes(rec['mem_p95_max'])}")
+        print(f"    - Coverage: {rec['mem_coverage']}/{rec['mem_total']} clusters")
+        print()
+        
+        if rec['cpu_total'] > 0:
+            print(f"  CPU: {rec['cpu_recommended_k8s']}")
+            print(f"    - Max observed: {cores_to_kubernetes(rec['cpu_max_max'])}")
+            print(f"    - P95 max: {cores_to_kubernetes(rec['cpu_p95_max'])}")
+            print(f"    - Coverage: {rec['cpu_coverage']}/{rec['cpu_total']} clusters")
+        else:
+            print(f"  CPU: No data available")
+        print()
+
+
+def update_yaml_file(yaml_path, recommendations, original_yaml):
+    """Update YAML file with recommended resource limits."""
+    updated = False
+    
+    for rec in recommendations:
+        if rec is None:
+            continue
+        
+        step_name_csv = rec['step_name']  # e.g., "step-build"
+        mem_k8s = rec['mem_recommended_k8s']
+        cpu_k8s = rec['cpu_recommended_k8s']
+        
+        # Convert "step-build" to "build" for YAML matching
+        step_name_yaml = step_name_csv.replace('step-', '') if step_name_csv.startswith('step-') else step_name_csv
+        
+        # Find the step in the YAML
+        steps = original_yaml.get('spec', {}).get('steps', [])
+        for step in steps:
+            if step.get('name') == step_name_yaml:
+                # Update or create computeResources
+                if 'computeResources' not in step:
+                    step['computeResources'] = {}
+                
+                if 'limits' not in step['computeResources']:
+                    step['computeResources']['limits'] = {}
+                if 'requests' not in step['computeResources']:
+                    step['computeResources']['requests'] = {}
+                
+                step['computeResources']['limits']['memory'] = mem_k8s
+                step['computeResources']['limits']['cpu'] = cpu_k8s
+                step['computeResources']['requests']['memory'] = mem_k8s
+                step['computeResources']['requests']['cpu'] = cpu_k8s
+                
+                updated = True
+                print(f"Updated step '{step_name_yaml}': memory={mem_k8s}, cpu={cpu_k8s}", file=sys.stderr)
+                break
+    
+    return updated
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Analyze resource consumption and provide recommendations',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # From piped input:
+  ./wrapper_for_promql_for_all_clusters.sh 7 --csv | ./analyze_resource_limits.py
+
+  # From YAML file (auto-runs data collection):
+  ./analyze_resource_limits.py --file /path/to/buildah.yaml
+  ./analyze_resource_limits.py --file https://github.com/.../buildah.yaml
+
+  # Update YAML file with recommendations:
+  ./analyze_resource_limits.py --file /path/to/buildah.yaml --update
+        """
+    )
+    parser.add_argument(
+        '--file',
+        help='YAML file path or GitHub URL to analyze (auto-runs data collection)'
+    )
+    parser.add_argument(
+        '--update',
+        action='store_true',
+        help='Update the YAML file with recommended resource limits'
+    )
+    parser.add_argument(
+        '--margin',
+        type=int,
+        default=10,
+        help='Safety margin percentage (default: 10)'
+    )
+    parser.add_argument(
+        '--days',
+        type=int,
+        default=7,
+        help='Number of days for data collection (default: 7)'
+    )
+    
+    args = parser.parse_args()
+    
+    # Determine input source
+    if args.file:
+        # Load YAML and extract task info
+        yaml_content, yaml_path = fetch_yaml_content(args.file)
+        task_name, steps, default_resources = extract_task_info(yaml_content)
+        
+        if not task_name:
+            print("Error: Could not extract task name from YAML", file=sys.stderr)
+            sys.exit(1)
+        
+        if not steps:
+            print("Error: Could not extract steps from YAML", file=sys.stderr)
+            sys.exit(1)
+        
+        # Run data collection
+        csv_data = run_data_collection(task_name, steps, args.days)
+    else:
+        # Read from stdin
+        if sys.stdin.isatty():
+            print("Error: No input provided. Use --file or pipe CSV data.", file=sys.stderr)
+            sys.exit(1)
+        csv_data = sys.stdin.read()
+        yaml_content = None
+        yaml_path = None
+        task_name = None
+        steps = None
+    
+    # Parse CSV data
+    data = parse_csv_data(csv_data)
+    if not data:
+        print("Error: No data found in CSV input", file=sys.stderr)
+        sys.exit(1)
+    
+    # Group by step
+    by_step = defaultdict(list)
+    for row in data:
+        step = row.get('step', '').strip()
+        if step:
+            by_step[step].append(row)
+    
+    # Analyze each step
+    recommendations = []
+    for step_name in sorted(by_step.keys()):
+        rec = analyze_step_data(step_name, by_step[step_name], args.margin)
+        if rec:
+            recommendations.append(rec)
+    
+    # Print analysis
+    print_analysis(recommendations, args.margin)
+    
+    # Update YAML if requested
+    if args.update and yaml_path and not yaml_path.startswith('http'):
+        updated = update_yaml_file(yaml_path, recommendations, yaml_content)
+        if updated:
+            with open(yaml_path, 'w') as f:
+                yaml.dump(yaml_content, f, default_flow_style=False, sort_keys=False, width=120)
+            print(f"\nUpdated YAML file: {yaml_path}", file=sys.stderr)
+        else:
+            print("Warning: No steps were updated in YAML file", file=sys.stderr)
+    elif args.update and yaml_path and yaml_path.startswith('http'):
+        print("Error: Cannot update remote file. Please use a local file path.", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()
+

--- a/task-mem-usage-scripts/get_component_for_pod.py
+++ b/task-mem-usage-scripts/get_component_for_pod.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import json
+import os
 import sys
 
 import requests
@@ -13,7 +14,7 @@ if len(sys.argv) < 4:
             {
                 "error": (
                     "usage: get_component_for_pod.py "
-                    "<token> <prometheus_host> <pod_name>"
+                    "<token> <prometheus_host> <pod_name> [namespace] [end_time] [days]"
                 )
             }
         )
@@ -21,13 +22,46 @@ if len(sys.argv) < 4:
     sys.exit(1)
 
 token, prom_host, pod = sys.argv[1:4]
+namespace = sys.argv[4] if len(sys.argv) > 4 else None
+end_time = sys.argv[5] if len(sys.argv) > 5 else None
+days = int(sys.argv[6]) if len(sys.argv) > 6 else 1
 
-url = f"https://{prom_host}/api/v1/query"
 headers = {
     "Content-Type": "application/json",
     "Authorization": f"Bearer {token}",
 }
-params = {"query": f'kube_pod_labels{{pod="{pod}"}}'}
+
+# Build query with namespace if provided (more accurate)
+# Use range query (like list_pods_for_a_particular_task.py) to find deleted pods
+# kube_pod_labels can be queried as a range to get historical data
+url = f"https://{prom_host}/api/v1/query_range"
+
+# Build the query string
+if namespace and namespace != "N/A" and namespace != "":
+    query = f'kube_pod_labels{{pod="{pod}",namespace="{namespace}"}}'
+else:
+    query = f'kube_pod_labels{{pod="{pod}"}}'
+
+# Use range query if end_time is provided (to find deleted pods)
+# This matches the approach in list_pods_for_a_particular_task.py
+if end_time and end_time != "N/A" and end_time != "" and days:
+    try:
+        start_time = int(end_time) - (days * 24 * 60 * 60)
+        params = {
+            "query": query,
+            "start": start_time,
+            "end": int(end_time),
+            # Same step calculation as list_pods_for_a_particular_task.py
+            "step": f"{days * 15}s",
+        }
+    except (ValueError, TypeError):
+        # Fallback to instant query if time conversion fails
+        url = f"https://{prom_host}/api/v1/query"
+        params = {"query": query}
+else:
+    # Use instant query for current pods
+    url = f"https://{prom_host}/api/v1/query"
+    params = {"query": query}
 
 try:
     response = requests.get(
@@ -41,27 +75,152 @@ if response.status_code != 200:
     print(json.dumps({"error": f"prometheus returned {response.status_code}"}))
     sys.exit(0)
 
-data = response.json().get("data", {}).get("result", [])
+# Handle instant query response
+response_data = response.json()
+data = response_data.get("data", {}).get("result", [])
+
+debug_mode = os.environ.get("DEBUG_COMPONENT_LOOKUP") == "1"
+
 if not data:
-    print(json.dumps({"component": "N/A", "application": "N/A", "pod": pod}))
-    sys.exit(0)
+    # Check if there's an error in the response
+    error_info = response_data.get("error")
+    if error_info:
+        if debug_mode:
+            print(
+                f"DEBUG: Prometheus query error for pod {pod}: {error_info}",
+                file=sys.stderr,
+            )
+    # No data found - pod might not exist or query returned empty
+    if debug_mode:
+        print(
+            f"DEBUG: No data found for pod {pod} (namespace={namespace}) "
+            f"in range query. Query params: {params}",
+            file=sys.stderr,
+        )
+    # Try without namespace filter if namespace was provided
+    if namespace and namespace != "N/A" and namespace != "":
+        if debug_mode:
+            print(
+                f"DEBUG: Retrying query without namespace filter for pod {pod}",
+                file=sys.stderr,
+            )
+        query_no_ns = f'kube_pod_labels{{pod="{pod}"}}'
+        if end_time and end_time != "N/A" and end_time != "" and days:
+            try:
+                start_time = int(end_time) - (days * 24 * 60 * 60)
+                params_no_ns = {
+                    "query": query_no_ns,
+                    "start": start_time,
+                    "end": int(end_time),
+                    "step": f"{days * 15}s",
+                }
+            except (ValueError, TypeError):
+                params_no_ns = {"query": query_no_ns}
+        else:
+            params_no_ns = {"query": query_no_ns}
 
-metric = data[0].get("metric", {})
+        try:
+            retry_response = requests.get(
+                url, headers=headers, params=params_no_ns, verify=False, timeout=30
+            )
+            if retry_response.status_code == 200:
+                retry_data = retry_response.json().get("data", {}).get("result", [])
+                if retry_data:
+                    data = retry_data
+                    if debug_mode:
+                        print(
+                            f"DEBUG: Found data without namespace filter for pod {pod}",
+                            file=sys.stderr,
+                        )
+        except Exception as exc:
+            if debug_mode:
+                print(
+                    f"DEBUG: Exception during retry without namespace: {exc}",
+                    file=sys.stderr,
+                )
 
+    if not data:
+        if debug_mode:
+            print(
+                f"DEBUG: No data found for pod {pod} after all attempts. "
+                f"Query was: {query}",
+                file=sys.stderr,
+            )
+        print(json.dumps({"component": "N/A", "application": "N/A", "pod": pod}))
+        sys.exit(0)
+
+# Get the first result's metric (handles both instant and range query formats)
+if isinstance(data, list) and len(data) > 0:
+    if isinstance(data[0], dict):
+        # Range query: data[0] = {"metric": {...}, "values": [[ts, val], ...]}
+        # Instant query: data[0] = {"metric": {...}, "value": [ts, val]}
+        metric = data[0].get("metric", {})
+    else:
+        metric = {}
+else:
+    metric = {}
+
+# Debug: Always print available label keys when DEBUG is enabled (via wrapper script)
+# This helps identify what labels are actually available
+if debug_mode:
+    all_labels = sorted(metric.keys())
+    print(
+        f"DEBUG: Available labels for pod {pod} (namespace={namespace}): {all_labels}",
+        file=sys.stderr,
+    )
+    # Also print a sample of label values that might be relevant
+    relevant_labels = {
+        k: v
+        for k, v in metric.items()
+        if any(
+            keyword in k.lower()
+            for keyword in ["component", "application", "app", "label"]
+        )
+    }
+    if relevant_labels:
+        print(
+            f"DEBUG: Relevant labels for pod {pod}: {relevant_labels}",
+            file=sys.stderr,
+        )
+
+# Expanded list of possible label keys for component
+# Prometheus converts special chars: / -> _, . -> _ (sometimes)
+# Labels may have "label_" prefix in some setups
+# Based on actual Prometheus data: label_appstudio_openshift_io_component
 component_keys = [
-    "appstudio_redhat_com_component",
+    "label_appstudio_openshift_io_component",  # Actual format found in Prometheus
     "label_appstudio_redhat_com_component",
+    "appstudio_openshift_io_component",
+    "appstudio_redhat_com_component",
+    "label_appstudio.redhat.com/component",
+    "label_appstudio.openshift.io/component",
     "appstudio.redhat.com/component",
+    "appstudio.openshift.io/component",
+    "label_component",
     "component",
+    "label_app_kubernetes_io_component",
     "app.kubernetes.io/component",
+    "app_kubernetes_io_component",
 ]
 
+# Expanded list of possible label keys for application
+# Based on actual Prometheus data: label_appstudio_openshift_io_application
 application_keys = [
-    "appstudio_redhat_com_application",
+    "label_appstudio_openshift_io_application",  # Actual format found in Prometheus
     "label_appstudio_redhat_com_application",
+    "appstudio_openshift_io_application",
+    "appstudio_redhat_com_application",
+    "label_appstudio.redhat.com/application",
+    "label_appstudio.openshift.io/application",
     "appstudio.redhat.com/application",
+    "appstudio.openshift.io/application",
+    "label_application",
     "application",
+    "label_app_kubernetes_io_name",
     "app.kubernetes.io/name",
+    "app_kubernetes_io_name",
+    "label_app",
+    "app",
 ]
 
 
@@ -73,9 +232,20 @@ def first_present(mapping, keys):
     return "N/A"
 
 
+component = first_present(metric, component_keys)
+application = first_present(metric, application_keys)
+
+# Debug output if enabled
+if os.environ.get("DEBUG_COMPONENT_LOOKUP") == "1":
+    print(
+        f"DEBUG: Found component='{component}', "
+        f"application='{application}' for pod {pod}",
+        file=sys.stderr,
+    )
+
 output = {
-    "component": first_present(metric, component_keys),
-    "application": first_present(metric, application_keys),
+    "component": component,
+    "application": application,
     "pod": pod,
 }
 

--- a/task-mem-usage-scripts/list_container_mem_usage_for_a_particular_pod.py
+++ b/task-mem-usage-scripts/list_container_mem_usage_for_a_particular_pod.py
@@ -1,52 +1,39 @@
+import json
 import sys
+
 import requests
 import urllib3
-import json
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 if len(sys.argv) <= 6:
-	sys.exit(1)
+    sys.exit(1)
 
 token = sys.argv[1]
-#url = "https://prometheus-k8s-openshift-monitoring.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/api/v1/query_range"
-url = "https://" + sys.argv[2] + "/api/v1/query_range"
+host = sys.argv[2]
 step_name = sys.argv[3]
 end_time_in_secs = int(sys.argv[4])
 pod_name = sys.argv[5]
 last_num_days = int(sys.argv[6])
 
+url = f"https://{host}/api/v1/query_range"
 headers = {
-            "Content-Type": "application/json",
-            "Authorization": f"Bearer {token}",
+    "Content-Type": "application/json",
+    "Authorization": f"Bearer {token}",
 }
 params = {
-            #"query": 'kube_pod_labels{label_tekton_dev_task="' + step_name + '", namespace=~".*-tenant"}',
-            "query": 'container_memory_max_usage_bytes{namespace=~".*-tenant", container="'+ step_name + '", pod=~"(' + pod_name + ')"}',
-            "step": (15 * last_num_days),
-            "start": (end_time_in_secs - (last_num_days * 24 * 60 * 60)),
-            "end": end_time_in_secs,
-        }
+    "query": (
+        "container_memory_max_usage_bytes"
+        f'{{namespace=~".*-tenant",container="{step_name}",pod=~"({pod_name})"}}'
+    ),
+    "step": 15 * last_num_days,
+    "start": end_time_in_secs - (last_num_days * 24 * 60 * 60),
+    "end": end_time_in_secs,
+}
 
-#print ("Inside Script ", sys.argv[0])
-#print ("token = ", token)
-#print ("Prometheuss Url = ", url)
-#print ("Container Name = ", step_name)
-#print ("Pod Name = ", pod_name)
-#print ("Last Num Days = ", last_num_days)
-#print ("Start Time in Secs = ", (end_time_in_secs - (last_num_days * 24 * 60 * 60)))
-#print ("End Time in Secs = ", end_time_in_secs)
-#print ("Headers = ", headers)
-#print ("Params to HTTP Request = ", params)
-
-response = requests.get(
-            url, headers=headers, params=params, verify=False, timeout=60
-        )
+response = requests.get(url, headers=headers, params=params, verify=False, timeout=60)
 
 if response.status_code == 200:
-	#print("Request successful.", file=sys.stderr)
-	#print(response.text)
-	print(json.dumps(response.json(), indent=4))
+    print(json.dumps(response.json(), indent=4))
 else:
-	print(f"Request failed with status code: {response.status_code}")
-
+    print(f"Request failed with status code: {response.status_code}")

--- a/task-mem-usage-scripts/list_container_mem_usage_for_a_particular_pod.py
+++ b/task-mem-usage-scripts/list_container_mem_usage_for_a_particular_pod.py
@@ -24,7 +24,8 @@ headers = {
 params = {
     "query": (
         "container_memory_max_usage_bytes"
-        f'{{namespace=~".*-tenant",container="{step_name}",pod=~"({pod_name})"}}'
+        f'{{namespace=~".*-tenant",container="{step_name}",'
+        f'pod=~"({pod_name})"}}'
     ),
     "step": 15 * last_num_days,
     "start": end_time_in_secs - (last_num_days * 24 * 60 * 60),

--- a/task-mem-usage-scripts/list_pods_for_a_particular_task.py
+++ b/task-mem-usage-scripts/list_pods_for_a_particular_task.py
@@ -1,42 +1,30 @@
 import sys
+
 import requests
 import urllib3
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 token = sys.argv[1]
-
-#url = "https://prometheus-k8s-openshift-monitoring.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/api/v1/query_range"
-url = "https://" + sys.argv[2] + "/api/v1/query_range"
+host = sys.argv[2]
 task_name = sys.argv[3]
-end_time_in_secs= int(sys.argv[4])
+end_time_in_secs = int(sys.argv[4])
 last_num_days = int(sys.argv[5])
 
+url = f"https://{host}/api/v1/query_range"
 headers = {
-            "Content-Type": "application/json",
-            "Authorization": f"Bearer {token}",
+    "Content-Type": "application/json",
+    "Authorization": f"Bearer {token}",
 }
 params = {
-            "query": 'kube_pod_labels{label_tekton_dev_task="' + task_name + '", namespace=~".*-tenant"}',
-            "step": (15 * last_num_days),
-            "start": (end_time_in_secs - (last_num_days * 24 * 60 * 60)),
-            "end": end_time_in_secs,
-        }
+    "query": (
+        "kube_pod_labels"
+        f'{{label_tekton_dev_task="{task_name}",namespace=~".*-tenant"}}'
+    ),
+    "step": 15 * last_num_days,
+    "start": end_time_in_secs - (last_num_days * 24 * 60 * 60),
+    "end": end_time_in_secs,
+}
 
-#print ("Inside Script ", sys.argv[0])
-#print ("token = ", token)
-#print ("Prometheuss Url = ", url)
-#print ("Task Name = ", task_name)
-#print ("Last Num Days = ", last_num_days)
-#print ("Start Time in Secs = ", (end_time_in_secs - (last_num_days * 24 * 60 * 60)))
-#print ("End Time in Secs = ", end_time_in_secs)
-#print ("step = ", (15 * last_num_days))
-#print ("Headers = ", headers)
-#print ("Params to HTTP Request = ", params)
-#sys.exit(0)
-
-response = requests.get(
-            url, headers=headers, params=params, verify=False, timeout=60
-        )
+response = requests.get(url, headers=headers, params=params, verify=False, timeout=60)
 print(response.text)
-

--- a/task-mem-usage-scripts/query_prometheus_instant.py
+++ b/task-mem-usage-scripts/query_prometheus_instant.py
@@ -27,4 +27,3 @@ resp = requests.get(
 )
 resp.raise_for_status()
 print(resp.text)
-

--- a/task-mem-usage-scripts/query_prometheus_instant.py
+++ b/task-mem-usage-scripts/query_prometheus_instant.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+import os
+import sys
+import requests
+import urllib3
+
+urllib3.disable_warnings()
+
+if len(sys.argv) != 2:
+    print("Usage: query_prometheus_instant.py '<promql>'", file=sys.stderr)
+    sys.exit(1)
+
+query = sys.argv[1]
+token = os.environ.get("PROM_TOKEN")
+host = os.environ.get("PROM_HOST")
+
+if not token or not host:
+    print("PROM_TOKEN and PROM_HOST must be set", file=sys.stderr)
+    sys.exit(1)
+
+resp = requests.get(
+    f"https://{host}/api/v1/query",
+    headers={"Authorization": f"Bearer {token}"},
+    params={"query": query},
+    verify=False,
+    timeout=180,
+)
+resp.raise_for_status()
+print(resp.text)
+

--- a/task-mem-usage-scripts/query_prometheus_range.py
+++ b/task-mem-usage-scripts/query_prometheus_range.py
@@ -1,24 +1,45 @@
-import json
+#!/usr/bin/env python3
 import sys
-
 import requests
 import urllib3
+import time
 
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+urllib3.disable_warnings()
 
-token, host, query, start, end = sys.argv[1:6]
+token, host, query, start, end = sys.argv[1:]
 
 url = f"https://{host}/api/v1/query_range"
+
 headers = {
     "Authorization": f"Bearer {token}",
-    "Content-Type": "application/json",
 }
+
+# Calculate time range in seconds
+start_ts = int(start)
+end_ts = int(end)
+duration = end_ts - start_ts
+
+# Adaptive step size based on time range to avoid Prometheus limits
+# Prometheus typically limits to ~11,000 data points per query
+# For longer ranges, use larger steps to stay within limits
+if duration <= 86400:  # <= 1 day
+    step = "30s"
+elif duration <= 604800:  # <= 7 days
+    step = "5m"  # 5 minutes for 7 days = ~2016 data points
+elif duration <= 2592000:  # <= 30 days
+    step = "15m"  # 15 minutes for 30 days = ~2880 data points
+else:
+    step = "1h"  # 1 hour for longer ranges
+
 params = {
     "query": query,
     "start": start,
     "end": end,
-    "step": 30,
+    "step": step,
 }
 
-response = requests.get(url, headers=headers, params=params, verify=False, timeout=60)
-print(json.dumps(response.json()))
+t0 = time.time()
+resp = requests.get(url, headers=headers, params=params, verify=False, timeout=180)
+resp.raise_for_status()
+print(resp.text)
+

--- a/task-mem-usage-scripts/query_prometheus_range.py
+++ b/task-mem-usage-scripts/query_prometheus_range.py
@@ -1,0 +1,20 @@
+import sys, requests, urllib3, json
+urllib3.disable_warnings()
+
+token, host, query, start, end = sys.argv[1:6]
+
+url = f"https://{host}/api/v1/query_range"
+headers = {
+    "Authorization": f"Bearer {token}",
+    "Content-Type": "application/json"
+}
+params = {
+    "query": query,
+    "start": start,
+    "end": end,
+    "step": 30
+}
+
+r = requests.get(url, headers=headers, params=params, verify=False, timeout=60)
+print(json.dumps(r.json()))
+

--- a/task-mem-usage-scripts/query_prometheus_range.py
+++ b/task-mem-usage-scripts/query_prometheus_range.py
@@ -42,4 +42,3 @@ t0 = time.time()
 resp = requests.get(url, headers=headers, params=params, verify=False, timeout=180)
 resp.raise_for_status()
 print(resp.text)
-

--- a/task-mem-usage-scripts/query_prometheus_range.py
+++ b/task-mem-usage-scripts/query_prometheus_range.py
@@ -1,20 +1,24 @@
-import sys, requests, urllib3, json
-urllib3.disable_warnings()
+import json
+import sys
+
+import requests
+import urllib3
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 token, host, query, start, end = sys.argv[1:6]
 
 url = f"https://{host}/api/v1/query_range"
 headers = {
     "Authorization": f"Bearer {token}",
-    "Content-Type": "application/json"
+    "Content-Type": "application/json",
 }
 params = {
     "query": query,
     "start": start,
     "end": end,
-    "step": 30
+    "step": 30,
 }
 
-r = requests.get(url, headers=headers, params=params, verify=False, timeout=60)
-print(json.dumps(r.json()))
-
+response = requests.get(url, headers=headers, params=params, verify=False, timeout=60)
+print(json.dumps(response.json()))

--- a/task-mem-usage-scripts/wrapper_for_promql.sh
+++ b/task-mem-usage-scripts/wrapper_for_promql.sh
@@ -2,6 +2,7 @@
 set -eu -o pipefail
 
 # usage: wrapper_for_promql.sh <task_name> <step_name> <last_num_days> <mode> [batch_size]
+
 task_name="$1"
 step_name="$2"
 last_num_days="$3"
@@ -10,31 +11,43 @@ batch_size="${5:-50}"
 
 cluster_name="$(oc config current-context | sed -E 's#.*/api-([^-]+-[^-]+-[^-]+).*#\1#')"
 user_token="$(oc whoami --show-token)"
-prometheus_url="$(oc -n openshift-monitoring get route | grep -w 'prometheus-k8s' | grep -v 'federate' | awk '{print $2}')"
-end_time_in_secs="$(date +%s)"
+prometheus_url="$(oc -n openshift-monitoring get route | awk '/prometheus-k8s/ && !/federate/ {print $2}')"
 
-# Get pods for task
+end_time_in_secs="$(date +%s)"
+start_time=$(( end_time_in_secs - last_num_days * 24 * 60 * 60 ))
+range_window="${last_num_days}d"
+
+# ------------------------------------------------------------
+# Get pods
+# ------------------------------------------------------------
 pod_list_raw="$(
-    python3 list_pods_for_a_particular_task.py \
-        "${user_token}" "${prometheus_url}" "${task_name}" \
-        "${end_time_in_secs}" "${last_num_days}" |
-    jq -r '.data.result[].metric.pod' 2>/dev/null |
-    sort -u
+  python3 list_pods_for_a_particular_task.py \
+    "${user_token}" "${prometheus_url}" "${task_name}" \
+    "${end_time_in_secs}" "${last_num_days}" |
+  jq -r '.data.result[].metric.pod' 2>/dev/null |
+  sort -u
 )"
 
 pods=()
-while IFS= read -r line; do
-    [ -n "$line" ] && pods+=("$line")
-done <<<"$pod_list_raw"
+while IFS= read -r pod; do
+  [ -n "$pod" ] && pods+=("$pod")
+done <<< "$pod_list_raw"
 
-[ "${#pods[@]}" -eq 0 ] && exit 0
+# ---------------- DEBUG GUARD ----------------
+if [ "${#pods[@]}" -eq 0 ]; then
+  echo "DEBUG: No pods found for task=${task_name} in cluster=${cluster_name}" >&2
+  exit 0
+fi
+# --------------------------------------------
 
-# accumulators (units: MB for output vars, bytes internally)
+# ------------------------------------------------------------
+# Global accumulators (MB)
+# ------------------------------------------------------------
 max_overall=0
 max_overall_pod=""
 max_overall_namespace="N/A"
-max_overall_app="N/A"
 max_overall_component="N/A"
+max_overall_app="N/A"
 
 perc95_overall=0
 perc90_overall=0
@@ -43,146 +56,106 @@ median_overall=0
 total="${#pods[@]}"
 start=0
 
+# ------------------------------------------------------------
+# Batch loop
+# ------------------------------------------------------------
 while [ $start -lt $total ]; do
-    end=$((start + batch_size))
-    [ $end -gt $total ] && end=$total
+  end=$(( start + batch_size ))
+  [ $end -gt $total ] && end=$total
 
-    # join batch pods with |
-    batch_pods=$(printf "%s|" "${pods[@]:$start:$((end-start))}")
-    batch_pods="${batch_pods%|}"
+  batch_pods=$(printf "%s|" "${pods[@]:$start:$((end-start))}")
+  batch_pods="${batch_pods%|}"
 
-    # fetch metrics for this batch (raw JSON)
-    result_json="$(
-        python3 list_container_mem_usage_for_a_particular_pod.py \
-            "${user_token}" "${prometheus_url}" "${step_name}" \
-            "${end_time_in_secs}" "${batch_pods}" "${last_num_days}" |
-        grep -v "Enter any Key" |
-        sed '0,/^{/d' || true
+  # ----------------------------------------------------------
+  # MAX memory (bytes → MB)
+  # ----------------------------------------------------------
+  max_query="max_over_time(container_memory_max_usage_bytes{namespace=~\".*-tenant\",container=\"${step_name}\",pod=~\"(${batch_pods})\"}[${range_window}])"
+
+  max_json="$(
+    python3 query_prometheus_range.py \
+      "${user_token}" "${prometheus_url}" \
+      "${max_query}" \
+      "${start_time}" "${end_time_in_secs}"
+  )"
+
+  max_entry="$(echo "$max_json" | jq '
+    .data.result[]? as $r |
+    ($r.values[][1] | tonumber | floor | select(. > 0)) as $v |
+    {value:$v, pod:$r.metric.pod, namespace:$r.metric.namespace}
+  ' | jq -s 'if length==0 then {} else max_by(.value) end')"
+
+  batch_max_bytes="$(echo "$max_entry" | jq -r '.value // 0')"
+  batch_max_mb=$(( batch_max_bytes / 1024 / 1024 ))
+
+  if (( batch_max_mb > max_overall )); then
+    max_overall="$batch_max_mb"
+    max_overall_pod="$(echo "$max_entry" | jq -r '.pod // ""')"
+    max_overall_namespace="$(echo "$max_entry" | jq -r '.namespace // "N/A"')"
+
+    comp_info="$(python3 get_component_for_pod.py "${user_token}" "${prometheus_url}" "${max_overall_pod}" 2>/dev/null || echo '{}')"
+    max_overall_component="$(echo "$comp_info" | jq -r '.component // "N/A"')"
+    max_overall_app="$(echo "$comp_info" | jq -r '.application // "N/A"')"
+  fi
+
+  # ----------------------------------------------------------
+  # Percentiles (PromQL does the math)
+  # ----------------------------------------------------------
+  for q in 0.95 0.90 0.50; do
+    p_query="quantile_over_time(${q},container_memory_working_set_bytes{namespace=~\".*-tenant\",container=\"${step_name}\",pod=~\"(${batch_pods})\"}[${range_window}])"
+
+    p_json="$(
+      python3 query_prometheus_range.py \
+        "${user_token}" "${prometheus_url}" \
+        "${p_query}" \
+        "${start_time}" "${end_time_in_secs}"
     )"
 
-    # find the single max entry (value, pod, namespace) in this batch (bytes)
-    max_entry="$(echo "$result_json" | jq '
-        .data.result[]? as $r |
-        ($r.values[][1] | tonumber | select(. != 0)) as $v |
-        {value: $v, pod: ($r.metric.pod // ""), namespace: ($r.metric.namespace // "")}
-    ' | jq -s 'if length==0 then {} else max_by(.value) end')"
+    # floor() is CRITICAL here
+    p_bytes="$(echo "$p_json" | jq '[.data.result[].values[][1] | tonumber | floor | select(. > 0)] | max // 0')"
+    p_mb=$(( p_bytes / 1024 / 1024 ))
 
-    batch_max_value=$(echo "$max_entry" | jq -r '.value // 0')
-    batch_max_pod=$(echo "$max_entry" | jq -r '.pod // ""')
-    batch_max_namespace=$(echo "$max_entry" | jq -r '.namespace // ""')
+    case "$q" in
+      0.95) (( p_mb > perc95_overall )) && perc95_overall="$p_mb" ;;
+      0.90) (( p_mb > perc90_overall )) && perc90_overall="$p_mb" ;;
+      0.50) (( p_mb > median_overall )) && median_overall="$p_mb" ;;
+    esac
+  done
 
-    # convert to MB (integer)
-    batch_max_value_mb=$(( (batch_max_value+0) / 1024 / 1024 ))
-
-    # try get component/application via helper (uses kube labels if available)
-    comp_info="$(python3 get_component_for_pod.py "${user_token}" "${prometheus_url}" "${batch_max_pod}" 2>/dev/null || echo '{}')"
-    component="$(echo "$comp_info" | jq -r '.component // "N/A"' 2>/dev/null || echo "N/A")"
-    application="$(echo "$comp_info" | jq -r '.application // "N/A"' 2>/dev/null || echo "N/A")"
-
-    # fallback: attempt to parse app/component from pod name pattern if helper didn't find anything
-    if [ "$component" = "N/A" ] && [ -n "$batch_max_pod" ]; then
-        if [[ "$batch_max_pod" =~ ^([a-z0-9-]+)-([a-z0-9-]+)-([a-f0-9]{8,}) ]]; then
-            fallback_app="${BASH_REMATCH[1]}"
-            fallback_comp="${BASH_REMATCH[2]}"
-            application="${application:-$fallback_app}"
-            component="${component:-$fallback_comp}"
-        fi
-    fi
-
-    # global max update
-    if (( batch_max_value_mb > max_overall )); then
-        max_overall="$batch_max_value_mb"
-        max_overall_pod="$batch_max_pod"
-        max_overall_namespace="${batch_max_namespace:-N/A}"
-        max_overall_app="${application:-N/A}"
-        max_overall_component="${component:-N/A}"
-    fi
-
-    # percentiles for the batch (bytes) -> convert -> consider global maxima of those percentiles
-    batch_perc95_bytes="$(echo "$result_json" | jq '[.data.result[].values[][1] | tonumber | select(. != 0)] as $d | if ($d|length)==0 then 0 else ($d|sort)[(length*0.95|round)-1] end' 2>/dev/null || echo 0)"
-    batch_perc90_bytes="$(echo "$result_json" | jq '[.data.result[].values[][1] | tonumber | select(. != 0)] as $d | if ($d|length)==0 then 0 else ($d|sort)[(length*0.90|round)-1] end' 2>/dev/null || echo 0)"
-    batch_median_bytes="$(echo "$result_json" | jq '[.data.result[].values[][1] | tonumber | select(. != 0)] as $d | if ($d|length)==0 then 0 else ($d|sort) as $s | if ((length%2)==1) then $s[(length/2|floor)] else (($s[(length/2-1)] + $s[(length/2)]) / 2) end end' 2>/dev/null || echo 0)"
-
-    # normalize nulls and convert to MB
-    [ "$batch_perc95_bytes" = "null" ] && batch_perc95_bytes=0
-    [ "$batch_perc90_bytes" = "null" ] && batch_perc90_bytes=0
-    [ "$batch_median_bytes" = "null" ] && batch_median_bytes=0
-
-    batch_perc95_mb=$(( (batch_perc95_bytes+0) / 1024 / 1024 ))
-    batch_perc90_mb=$(( (batch_perc90_bytes+0) / 1024 / 1024 ))
-    batch_median_mb=$(( (batch_median_bytes+0) / 1024 / 1024 ))
-
-    (( batch_perc95_mb > perc95_overall )) && perc95_overall="$batch_perc95_mb"
-    (( batch_perc90_mb > perc90_overall )) && perc90_overall="$batch_perc90_mb"
-    (( batch_median_mb > median_overall )) && median_overall="$batch_median_mb"
-
-    start=$((start + batch_size))
+  start=$(( start + batch_size ))
 done
 
-# OUTPUT: depending on mode
+# ------------------------------------------------------------
+# OUTPUT
+# ------------------------------------------------------------
 case "$OUTPUT_MODE" in
-    --json)
-        jq -n \
-          --arg cluster "$cluster_name" \
-          --arg task "$task_name" \
-          --arg step "$step_name" \
-          --argjson max_mem "$max_overall" \
-          --arg pod "$max_overall_pod" \
-          --arg ns "$max_overall_namespace" \
-          --arg comp "$max_overall_component" \
-          --arg app "$max_overall_app" \
-          --argjson p95 "$perc95_overall" \
-          --argjson p90 "$perc90_overall" \
-          --argjson med "$median_overall" \
-          '{
-            cluster: $cluster,
-            task: $task,
-            step: $step,
-            max_mem_mb: $max_mem,
-            max_mem_pod: $pod,
-            namespace: $ns,
-            component: $comp,
-            application: $app,
-            p95_mb: $p95,
-            p90_mb: $p90,
-            median_mb: $med
-          }'
-    ;;
-    --csv)
-        # print CSV data row only (no header)
-        # ensure values are quoted CSV-safe
-        printf '"%s","%s","%s","%s","%s","%s","%s","%s","%s","%s","%s"\n' \
-            "$cluster_name" "$task_name" "$step_name" "$max_overall" \
-            "$max_overall_pod" "$max_overall_namespace" "$max_overall_component" \
-            "$max_overall_app" "$perc95_overall" "$perc90_overall" "$median_overall"
-    ;;
-    --color)
-        RED="\033[1;31m"
-        GREEN="\033[1;32m"
-        CYAN="\033[1;36m"
-        NC="\033[0m"
-
-        echo -e "${CYAN}Cluster:${NC}        $cluster_name"
-        echo -e "${CYAN}Task:${NC}           $task_name"
-        echo -e "${CYAN}Step:${NC}           $step_name"
-        echo -e "${RED}Max Mem:${NC}        ${max_overall} MB"
-        echo -e "${GREEN}Pod:${NC}            ${max_overall_pod}"
-        echo -e "${CYAN}Namespace:${NC}      ${max_overall_namespace}"
-        echo -e "${CYAN}Application:${NC}    ${max_overall_app}"
-        echo -e "${CYAN}Component:${NC}      ${max_overall_component}"
-        echo -e "${CYAN}95th:${NC}           ${perc95_overall} MB"
-        echo -e "${CYAN}90th:${NC}           ${perc90_overall} MB"
-        echo -e "${CYAN}Median:${NC}         ${median_overall} MB"
-        # blank line between entries (helps separating multiple outputs)
-        echo
-    ;;
-    --text|*)
-        echo "cluster_name=\"${cluster_name}\", task_name=\"${task_name}\", step_name=\"${step_name}\", \
-Max_mem=\"${max_overall} MB\", Max_mem_pod=\"${max_overall_pod}\", \
-Max_mem_namespace=\"${max_overall_namespace}\", \
-Max_mem_component=\"${max_overall_component}\", \
-Max_mem_application=\"${max_overall_app}\", \
-95_Pctl_Mem=\"${perc95_overall} MB\", 90_Pctl_Mem=\"${perc90_overall} MB\", Median_Mem=\"${median_overall} MB\""
-    ;;
+  --csv)
+    printf '"%s","%s","%s","%s","%s","%s","%s","%s","%s","%s","%s"\n' \
+      "$cluster_name" "$task_name" "$step_name" "$max_overall" \
+      "$max_overall_pod" "$max_overall_namespace" "$max_overall_component" \
+      "$max_overall_app" "$perc95_overall" "$perc90_overall" "$median_overall"
+  ;;
+  --json)
+    jq -n \
+      --arg cluster "$cluster_name" \
+      --arg task "$task_name" \
+      --arg step "$step_name" \
+      --argjson max "$max_overall" \
+      --arg pod "$max_overall_pod" \
+      --arg ns "$max_overall_namespace" \
+      --arg comp "$max_overall_component" \
+      --arg app "$max_overall_app" \
+      --argjson p95 "$perc95_overall" \
+      --argjson p90 "$perc90_overall" \
+      --argjson med "$median_overall" \
+      '{
+        cluster:$cluster, task:$task, step:$step,
+        max_mem_mb:$max, max_mem_pod:$pod,
+        namespace:$ns, component:$comp, application:$app,
+        p95_mb:$p95, p90_mb:$p90, median_mb:$med
+      }'
+  ;;
+  *)
+    echo "cluster=${cluster_name}, task=${task_name}, step=${step_name}, max=${max_overall}MB, p95=${perc95_overall}MB, p90=${perc90_overall}MB, median=${median_overall}MB"
+  ;;
 esac
 

--- a/task-mem-usage-scripts/wrapper_for_promql.sh
+++ b/task-mem-usage-scripts/wrapper_for_promql.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
-set -eu -o pipefail
+#!/usr/bin/env bash
+set -euo pipefail
 
 # usage: wrapper_for_promql.sh <task_name> <step_name> <last_num_days> <mode> [batch_size]
 
@@ -14,35 +14,30 @@ user_token="$(oc whoami --show-token)"
 prometheus_url="$(oc -n openshift-monitoring get route | awk '/prometheus-k8s/ && !/federate/ {print $2}')"
 
 end_time_in_secs="$(date +%s)"
-start_time=$(( end_time_in_secs - last_num_days * 24 * 60 * 60 ))
+start_time="$((end_time_in_secs - last_num_days * 24 * 60 * 60))"
 range_window="${last_num_days}d"
 
-# ------------------------------------------------------------
-# Get pods
-# ------------------------------------------------------------
 pod_list_raw="$(
-  python3 list_pods_for_a_particular_task.py \
-    "${user_token}" "${prometheus_url}" "${task_name}" \
-    "${end_time_in_secs}" "${last_num_days}" |
-  jq -r '.data.result[].metric.pod' 2>/dev/null |
-  sort -u
+    python3 list_pods_for_a_particular_task.py \
+        "$user_token" \
+        "$prometheus_url" \
+        "$task_name" \
+        "$end_time_in_secs" \
+        "$last_num_days" |
+    jq -r '.data.result[].metric.pod' 2>/dev/null |
+    sort -u
 )"
 
 pods=()
 while IFS= read -r pod; do
-  [ -n "$pod" ] && pods+=("$pod")
+    [ -n "$pod" ] && pods+=("$pod")
 done <<< "$pod_list_raw"
 
-# ---------------- DEBUG GUARD ----------------
 if [ "${#pods[@]}" -eq 0 ]; then
-  echo "DEBUG: No pods found for task=${task_name} in cluster=${cluster_name}" >&2
-  exit 0
+    echo "DEBUG: No pods found for task=${task_name} in cluster=${cluster_name}" >&2
+    exit 0
 fi
-# --------------------------------------------
 
-# ------------------------------------------------------------
-# Global accumulators (MB)
-# ------------------------------------------------------------
 max_overall=0
 max_overall_pod=""
 max_overall_namespace="N/A"
@@ -56,106 +51,124 @@ median_overall=0
 total="${#pods[@]}"
 start=0
 
-# ------------------------------------------------------------
-# Batch loop
-# ------------------------------------------------------------
-while [ $start -lt $total ]; do
-  end=$(( start + batch_size ))
-  [ $end -gt $total ] && end=$total
+while [ "$start" -lt "$total" ]; do
+    end="$((start + batch_size))"
+    [ "$end" -gt "$total" ] && end="$total"
 
-  batch_pods=$(printf "%s|" "${pods[@]:$start:$((end-start))}")
-  batch_pods="${batch_pods%|}"
+    batch_pods="$(printf "%s|" "${pods[@]:start:end-start}")"
+    batch_pods="${batch_pods%|}"
 
-  # ----------------------------------------------------------
-  # MAX memory (bytes → MB)
-  # ----------------------------------------------------------
-  max_query="max_over_time(container_memory_max_usage_bytes{namespace=~\".*-tenant\",container=\"${step_name}\",pod=~\"(${batch_pods})\"}[${range_window}])"
+    max_query="max_over_time(container_memory_max_usage_bytes{namespace=~\".*-tenant\",container=\"${step_name}\",pod=~\"(${batch_pods})\"}[${range_window}])"
 
-  max_json="$(
-    python3 query_prometheus_range.py \
-      "${user_token}" "${prometheus_url}" \
-      "${max_query}" \
-      "${start_time}" "${end_time_in_secs}"
-  )"
-
-  max_entry="$(echo "$max_json" | jq '
-    .data.result[]? as $r |
-    ($r.values[][1] | tonumber | floor | select(. > 0)) as $v |
-    {value:$v, pod:$r.metric.pod, namespace:$r.metric.namespace}
-  ' | jq -s 'if length==0 then {} else max_by(.value) end')"
-
-  batch_max_bytes="$(echo "$max_entry" | jq -r '.value // 0')"
-  batch_max_mb=$(( batch_max_bytes / 1024 / 1024 ))
-
-  if (( batch_max_mb > max_overall )); then
-    max_overall="$batch_max_mb"
-    max_overall_pod="$(echo "$max_entry" | jq -r '.pod // ""')"
-    max_overall_namespace="$(echo "$max_entry" | jq -r '.namespace // "N/A"')"
-
-    comp_info="$(python3 get_component_for_pod.py "${user_token}" "${prometheus_url}" "${max_overall_pod}" 2>/dev/null || echo '{}')"
-    max_overall_component="$(echo "$comp_info" | jq -r '.component // "N/A"')"
-    max_overall_app="$(echo "$comp_info" | jq -r '.application // "N/A"')"
-  fi
-
-  # ----------------------------------------------------------
-  # Percentiles (PromQL does the math)
-  # ----------------------------------------------------------
-  for q in 0.95 0.90 0.50; do
-    p_query="quantile_over_time(${q},container_memory_working_set_bytes{namespace=~\".*-tenant\",container=\"${step_name}\",pod=~\"(${batch_pods})\"}[${range_window}])"
-
-    p_json="$(
-      python3 query_prometheus_range.py \
-        "${user_token}" "${prometheus_url}" \
-        "${p_query}" \
-        "${start_time}" "${end_time_in_secs}"
+    max_json="$(
+        python3 query_prometheus_range.py \
+            "$user_token" \
+            "$prometheus_url" \
+            "$max_query" \
+            "$start_time" \
+            "$end_time_in_secs"
     )"
 
-    # floor() is CRITICAL here
-    p_bytes="$(echo "$p_json" | jq '[.data.result[].values[][1] | tonumber | floor | select(. > 0)] | max // 0')"
-    p_mb=$(( p_bytes / 1024 / 1024 ))
+    max_entry="$(
+        echo "$max_json" | jq '
+            .data.result[]? as $r
+            | ($r.values[][1] | tonumber | floor | select(. > 0)) as $v
+            | {value:$v, pod:$r.metric.pod, namespace:$r.metric.namespace}
+        ' | jq -s 'if length == 0 then {} else max_by(.value) end'
+    )"
 
-    case "$q" in
-      0.95) (( p_mb > perc95_overall )) && perc95_overall="$p_mb" ;;
-      0.90) (( p_mb > perc90_overall )) && perc90_overall="$p_mb" ;;
-      0.50) (( p_mb > median_overall )) && median_overall="$p_mb" ;;
-    esac
-  done
+    batch_max_bytes="$(echo "$max_entry" | jq -r '.value // 0')"
+    batch_max_mb="$((batch_max_bytes / 1024 / 1024))"
 
-  start=$(( start + batch_size ))
+    if [ "$batch_max_mb" -gt "$max_overall" ]; then
+        max_overall="$batch_max_mb"
+        max_overall_pod="$(echo "$max_entry" | jq -r '.pod // ""')"
+        max_overall_namespace="$(echo "$max_entry" | jq -r '.namespace // "N/A"')"
+
+        comp_info="$(
+            python3 get_component_for_pod.py \
+                "$user_token" \
+                "$prometheus_url" \
+                "$max_overall_pod" 2>/dev/null || echo '{}'
+        )"
+
+        max_overall_component="$(echo "$comp_info" | jq -r '.component // "N/A"')"
+        max_overall_app="$(echo "$comp_info" | jq -r '.application // "N/A"')"
+    fi
+
+    for q in 0.95 0.90 0.50; do
+        p_query="quantile_over_time(${q},container_memory_working_set_bytes{namespace=~\".*-tenant\",container=\"${step_name}\",pod=~\"(${batch_pods})\"}[${range_window}])"
+
+        p_json="$(
+            python3 query_prometheus_range.py \
+                "$user_token" \
+                "$prometheus_url" \
+                "$p_query" \
+                "$start_time" \
+                "$end_time_in_secs"
+        )"
+
+        p_bytes="$(
+            echo "$p_json" |
+            jq '[.data.result[].values[][1] | tonumber | floor | select(. > 0)] | max // 0'
+        )"
+
+        p_mb="$((p_bytes / 1024 / 1024))"
+
+        case "$q" in
+            0.95) [ "$p_mb" -gt "$perc95_overall" ] && perc95_overall="$p_mb" ;;
+            0.90) [ "$p_mb" -gt "$perc90_overall" ] && perc90_overall="$p_mb" ;;
+            0.50) [ "$p_mb" -gt "$median_overall" ] && median_overall="$p_mb" ;;
+        esac
+    done
+
+    start="$((start + batch_size))"
 done
 
-# ------------------------------------------------------------
-# OUTPUT
-# ------------------------------------------------------------
 case "$OUTPUT_MODE" in
-  --csv)
-    printf '"%s","%s","%s","%s","%s","%s","%s","%s","%s","%s","%s"\n' \
-      "$cluster_name" "$task_name" "$step_name" "$max_overall" \
-      "$max_overall_pod" "$max_overall_namespace" "$max_overall_component" \
-      "$max_overall_app" "$perc95_overall" "$perc90_overall" "$median_overall"
-  ;;
-  --json)
-    jq -n \
-      --arg cluster "$cluster_name" \
-      --arg task "$task_name" \
-      --arg step "$step_name" \
-      --argjson max "$max_overall" \
-      --arg pod "$max_overall_pod" \
-      --arg ns "$max_overall_namespace" \
-      --arg comp "$max_overall_component" \
-      --arg app "$max_overall_app" \
-      --argjson p95 "$perc95_overall" \
-      --argjson p90 "$perc90_overall" \
-      --argjson med "$median_overall" \
-      '{
-        cluster:$cluster, task:$task, step:$step,
-        max_mem_mb:$max, max_mem_pod:$pod,
-        namespace:$ns, component:$comp, application:$app,
-        p95_mb:$p95, p90_mb:$p90, median_mb:$med
-      }'
-  ;;
-  *)
-    echo "cluster=${cluster_name}, task=${task_name}, step=${step_name}, max=${max_overall}MB, p95=${perc95_overall}MB, p90=${perc90_overall}MB, median=${median_overall}MB"
-  ;;
+    --csv)
+        printf '"%s","%s","%s","%s","%s","%s","%s","%s","%s","%s","%s"\n' \
+            "$cluster_name" \
+            "$task_name" \
+            "$step_name" \
+            "$max_overall" \
+            "$max_overall_pod" \
+            "$max_overall_namespace" \
+            "$max_overall_component" \
+            "$max_overall_app" \
+            "$perc95_overall" \
+            "$perc90_overall" \
+            "$median_overall"
+        ;;
+    --json)
+        jq -n \
+            --arg cluster "$cluster_name" \
+            --arg task "$task_name" \
+            --arg step "$step_name" \
+            --argjson max "$max_overall" \
+            --arg pod "$max_overall_pod" \
+            --arg ns "$max_overall_namespace" \
+            --arg comp "$max_overall_component" \
+            --arg app "$max_overall_app" \
+            --argjson p95 "$perc95_overall" \
+            --argjson p90 "$perc90_overall" \
+            --argjson med "$median_overall" \
+            '{
+                cluster:$cluster,
+                task:$task,
+                step:$step,
+                max_mem_mb:$max,
+                max_mem_pod:$pod,
+                namespace:$ns,
+                component:$comp,
+                application:$app,
+                p95_mb:$p95,
+                p90_mb:$p90,
+                median_mb:$med
+            }'
+        ;;
+    *)
+        echo "cluster=${cluster_name}, task=${task_name}, step=${step_name}, max=${max_overall}MB, p95=${perc95_overall}MB, p90=${perc90_overall}MB, median=${median_overall}MB"
+        ;;
 esac
 

--- a/task-mem-usage-scripts/wrapper_for_promql_for_all_clusters.sh
+++ b/task-mem-usage-scripts/wrapper_for_promql_for_all_clusters.sh
@@ -28,12 +28,12 @@ STEPS="step-build step-push step-sbom-syft-generate step-prepare-sboms step-uplo
 #STEPS="step-build"
 
 # Get all contexts or use specific one for testing
-#CONTEXTS="$(kubectl config get-contexts -o name 2>/dev/null | xargs || echo 'default/api-stone-prd-rh01-pg1f-p1-openshiftapps-com:6443/smodak')"
-CONTEXTS="default/api-stone-prd-rh01-pg1f-p1-openshiftapps-com:6443/smodak"
+CONTEXTS="$(kubectl config get-contexts -o name 2>/dev/null | xargs || echo 'default/api-stone-prd-rh01-pg1f-p1-openshiftapps-com:6443/smodak')"
+#CONTEXTS="default/api-stone-prd-rh01-pg1f-p1-openshiftapps-com:6443/smodak"
 
 
-# CSV header matching the output format: cluster,task,step,pod_max_memory,pod_namespace_mem,component,application,mem_max_mb,mem_p95_mb,mem_p90_mb,mem_median_mb,pod_max_cpu,pod_namespace_cpu,cpu_max,cpu_p95,cpu_p90,cpu_median
-echo '"cluster","task","step","pod_max_memory","pod_namespace_mem","component","application","mem_max_mb","mem_p95_mb","mem_p90_mb","mem_median_mb","pod_max_cpu","pod_namespace_cpu","cpu_max","cpu_p95","cpu_p90","cpu_median"'
+# CSV header matching the output format: cluster, task, step, pod_max_mem, namespace_max_mem, component_max_mem, application_max_mem, mem_max_mb, mem_p95_mb, mem_p90_mb, mem_median_mb, pod_max_cpu, namespace_max_cpu, component_max_cpu, application_max_cpu, cpu_max, cpu_p95, cpu_p90, cpu_median
+echo '"cluster", "task", "step", "pod_max_mem", "namespace_max_mem", "component_max_mem", "application_max_mem", "mem_max_mb", "mem_p95_mb", "mem_p90_mb", "mem_median_mb", "pod_max_cpu", "namespace_max_cpu", "component_max_cpu", "application_max_cpu", "cpu_max", "cpu_p95", "cpu_p90", "cpu_median"'
 
 for ctx in ${CONTEXTS}; do
     kubectl config use-context "$ctx" >/dev/null 2>&1 || continue

--- a/task-mem-usage-scripts/wrapper_for_promql_for_all_clusters.sh
+++ b/task-mem-usage-scripts/wrapper_for_promql_for_all_clusters.sh
@@ -1,45 +1,54 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 if [ "$#" -lt 1 ]; then
-    echo "Usage: $0 <last_num_days> [--text|--color|--csv|--json]"
+    echo "Usage: $0 <last_num_days> [--text|--color|--csv|--json]" >&2
     exit 1
 fi
 
 last_num_days="$1"
 shift
 
-# Default output mode
 OUTPUT_MODE="--text"
-if [ $# -gt 0 ]; then
+if [ "$#" -gt 0 ]; then
     case "$1" in
-        --text|--color|--csv|--json) OUTPUT_MODE="$1" ;;
+        --text|--color|--csv|--json)
+            OUTPUT_MODE="$1"
+            ;;
         *)
-            echo "Unknown option: $1"
+            echo "Unknown option: $1" >&2
             exit 1
             ;;
     esac
 fi
 
-# Single-context for now (replace with kubectl contexts if needed)
-CONTEXTS="`kubectl config get-contexts -o name | xargs`"
-# override for testing / single cluster if desired:
-#CONTEXTS="default/api-stone-prd-rh01-pg1f-p1-openshiftapps-com:6443/smodak"
+CONTEXTS="$(kubectl config get-contexts -o name)"
+CONTEXTS="default/api-stone-prd-rh01-pg1f-p1-openshiftapps-com:6443/smodak"
 
 task_name="buildah"
-container_names="step-build step-push step-sbom-syft-generate step-prepare-sboms step-upload-sbom"
+container_names=(
+    step-build
+    step-push
+    step-sbom-syft-generate
+    step-prepare-sboms
+    step-upload-sbom
+)
 
-# If CSV mode, print header once
 if [ "$OUTPUT_MODE" = "--csv" ]; then
     echo '"cluster","task","step","max_mem_mb","pod","namespace","component","application","p95_mb","p90_mb","median_mb"'
 fi
 
 for context in ${CONTEXTS}; do
-    kubectl config use-context "${context}" &> /dev/null || continue
+    if ! kubectl config use-context "$context" >/dev/null 2>&1; then
+        continue
+    fi
 
-    for container in ${container_names}; do
-        # call wrapper and let it print one row (or text/color/json)
-        ./wrapper_for_promql.sh "${task_name}" "${container}" "${last_num_days}" "${OUTPUT_MODE}"
+    for container in "${container_names[@]}"; do
+        ./wrapper_for_promql.sh \
+            "$task_name" \
+            "$container" \
+            "$last_num_days" \
+            "$OUTPUT_MODE"
     done
 done
 


### PR DESCRIPTION
This change fixes a fundamental accuracy issue in memory percentile computation
(p95 / p90 / median) caused by per-batch aggregation in shell.

Previously, percentiles were calculated independently for each batch of pods
and then merged by taking the maximum across batches. This approach is
mathematically incorrect and could significantly overestimate memory pressure,
especially when batch sizes or pod lifetimes varied.

Key changes:
- Move percentile computation fully into PromQL using quantile_over_time()
- Restrict batching to transport concerns only (pod regex size), not statistics
- Preserve exact max memory calculation using max_over_time()
- Switch percentile metric to container_memory_working_set_bytes for more
  representative memory pressure
- Floor PromQL floating-point samples in jq to ensure bash-safe arithmetic
- Add a debug guard when no pods are found for a task/cluster
- Make the script compatible with older bash versions (no mapfile usage)

Results:
- Statistically correct percentiles across all pods and time windows
- Stable and reproducible results independent of batch size
- No bash arithmetic errors from floating-point Prometheus samples
- Cleaner separation between data collection and aggregation logic

* Results **BEFORE** Patching:
```bash
$ ./wrapper_for_promql_for_all_clusters.sh 1 --csv
"cluster","task","step","max_mem_mb","pod","namespace","component","application","p95_mb","p90_mb","median_mb"
"stone-prd-rh01","buildah","step-build","8192","maestro-on-pull-request-xj7dc-build-container-pod","maestro-rhtap-tenant","N/A","N/A","32","32","32"
"stone-prd-rh01","buildah","step-push","4096","mintmaker-renovate-image-on-push-w8f7h-build-container-pod","konflux-mintmaker-tenant","N/A","N/A","5","5","5"
"stone-prd-rh01","buildah","step-sbom-syft-generate","4096","mintmaker-renovate-image-on-push-w8f7h-build-container-pod","konflux-mintmaker-tenant","N/A","N/A","6","6","6"
"stone-prd-rh01","buildah","step-prepare-sboms","189","rhsm-api-proxy-on-pull-request-4tbbp-build-container-pod","teamnado-konflux-tenant","N/A","N/A","5","5","5"
"stone-prd-rh01","buildah","step-upload-sbom","46","crc-caddy-plugin-on-pull-request-ss22g-build-container-pod","hcm-eng-prod-tenant","N/A","N/A","5","5","5"
```
* Results **AFTER** Patching:
```bash
$ ./wrapper_for_promql_for_all_clusters.sh 1 --csv
"cluster","task","step","max_mem_mb","pod","namespace","component","application","p95_mb","p90_mb","median_mb"
"stone-prd-rh01","buildah","step-build","8192","maestro-on-pull-request-xj7dc-build-container-pod","maestro-rhtap-tenant","N/A","N/A","8191","8190","8183"
"stone-prd-rh01","buildah","step-push","4096","mintmaker-renovate-image-on-push-w8f7h-build-container-pod","konflux-mintmaker-tenant","N/A","N/A","471","445","59"
"stone-prd-rh01","buildah","step-sbom-syft-generate","4096","mintmaker-renovate-image-on-push-w8f7h-build-container-pod","konflux-mintmaker-tenant","N/A","N/A","1264","726","49"
"stone-prd-rh01","buildah","step-prepare-sboms","189","rhsm-api-proxy-on-pull-request-4tbbp-build-container-pod","teamnado-konflux-tenant","N/A","N/A","154","154","33"
"stone-prd-rh01","buildah","step-upload-sbom","46","crc-caddy-plugin-on-pull-request-ss22g-build-container-pod","hcm-eng-prod-tenant","N/A","N/A","30","23","7"
```

While the MAX Mem usage data is correct in both the cases, but from the above data we can see that the accuracy of 95 percentile, 90th percentile & median data has improved a lot.