### PR TITLE
Add --update --file feature to update local YAML files directly

### DIFF
--- a/tools/task-mem-and-cpu-usage-scripts/wrapper_for_promql_for_all_clusters.sh
+++ b/tools/task-mem-and-cpu-usage-scripts/wrapper_for_promql_for_all_clusters.sh
@@ -30,13 +30,18 @@ while [ "$#" -gt 0 ]; do
     shift
 done
 
-TASK_NAME="buildah"
-STEPS="step-build step-push step-sbom-syft-generate step-prepare-sboms step-upload-sbom"
+#TASK_NAME="buildah"
+#STEPS="step-build step-push step-prepare-sboms step-upload-sbom"
+#STEPS="step-build step-push step-sbom-syft-generate step-prepare-sboms step-upload-sbom"
 #STEPS="step-build"
+#STEPS="step-build step-push"
 
 # Get all contexts or use specific one for testing
 CONTEXTS="$(kubectl config get-contexts -o name 2>/dev/null | xargs || echo 'default/api-stone-prd-rh01-pg1f-p1-openshiftapps-com:6443/smodak')"
+#CONTEXTS="default/api-stone-prd-rh01-pg1f-p1-openshiftapps-com:6443/smodak default/api-stone-prod-p01-wcfb-p1-openshiftapps-com:6443/smodak default/api-kflux-prd-rh02-0fk9-p1-openshiftapps-com:6443/smodak default/api-kflux-prd-rh03-nnv1-p1-openshiftapps-com:6443/smodak default/api-stone-prod-p02-hjvn-p1-openshiftapps-com:6443/smodak default/api-kflux-stg-es01-21tc-p1-openshiftapps-com:6443/smodak"
 #CONTEXTS="default/api-stone-prd-rh01-pg1f-p1-openshiftapps-com:6443/smodak"
+#CONTEXTS="default/api-stone-prod-p01-wcfb-p1-openshiftapps-com:6443/smodak"
+#CONTEXTS="default/api-stone-prd-rh01-pg1f-p1-openshiftapps-com:6443/smodak default/api-stone-prod-p01-wcfb-p1-openshiftapps-com:6443/smodak default/api-kflux-prd-rh02-0fk9-p1-openshiftapps-com:6443/smodak default/api-kflux-stg-es01-21tc-p1-openshiftapps-com:6443/smodak"
 
 # Create temporary file for CSV output
 TMP_CSV=$(mktemp)


### PR DESCRIPTION
Add --update --file feature to update local YAML files directly

MAJOR CORE LOGIC CHANGES (New Feature: --update --file):

1. NEW FEATURE: Added ability to update local YAML files directly:
   - --update --file <local_file> now updates the file in-place
   - Previously only generated patch files for remote URLs
   - Loads recommendations from cache (no re-analysis needed)
   - Auto-detects missing cache and runs analysis automatically

2. Refactored update_yaml_file() for formatting preservation:
   - Replaced YAML parsing/dumping with line-by-line text processing
   - Prevents unwanted reformatting (quotes, ordering, spacing)
   - Preserves all comments and original YAML structure
   - Only modifies memory and cpu fields within computeResources sections

3. Implemented two-pass processing algorithm:
   - First pass: Collects all step positions (line index, step name)
   - Second pass: Processes steps in reverse order (bottom to top)
   - Prevents index shifting issues when inserting new lines

4. Enhanced step detection logic:
   - Pattern 1: Handles "  - name: stepname" format
   - Pattern 2: Handles "    name: stepname" format (after image:)
   - Robust lookback logic to distinguish step-level name: from nested fields

5. Dynamic step position tracking:
   - Accounts for line shifts from previous insertions
   - Estimates shift based on steps processed before current step
   - Searches in wider range to find current step position after shifts

6. Fixed indent calculation:
   - Distinguishes step_indent (step name line) from step_content_indent (step fields)
   - Detects step_content_indent by scanning for image:/env:/script: fields
   - Ensures computeResources blocks use correct 4-space indent (matching image:)

7. Improved computeResources handling:
   - Detects existing computeResources at correct indent level
   - Updates memory/cpu values in-place preserving original indentation
   - Creates new computeResources blocks with proper structure
   - Handles missing fields (adds cpu/memory if absent)

8. Added step validation for --update --file:
   - Validates cached recommendations match file being updated
   - Warns if cache has steps not in file (will be skipped)
   - Warns if file has steps not in cache (won't be updated)
   - Errors if no matching steps found (prevents incorrect updates)

MINOR CHANGES:

1. Added --debug flag:
   - Wraps all debug print statements with if debug: checks
   - Provides detailed processing information when enabled
   - Clean output by default, verbose output with --debug

2. Added --analyze-again / --aa flag:
   - Forces re-analysis even when cache exists
   - Used with --update --file <local_file> to refresh recommendations

3. Updated --update behavior:
   - --update --file <local_file>: Loads from cache by default (no re-analysis)
   - --update (without --file): Uses most recent cache (existing behavior)

4. Documentation updates:
   - Updated README.md with new --update --file feature and usage examples
   - Updated help text with --debug and --analyze-again options

5. Code quality improvements:
   - Fixed long lines (E501) by splitting list comprehensions
   - Improved code readability

The new --update --file feature allows users to update local YAML files directly
using cached recommendations, updating only memory and cpu fields within
computeResources sections while preserving all other YAML formatting, comments,
and structure.

Assisted-by: Cursor-AI

* With the above changes, user can first do the analysis like:
```
$ ./analyze_resource_limits.py --file https://github.com/konflux-ci/build-definitions/blob/main/task/buildah/0.7/buildah.yaml --margin 5 --days 10
Collecting data for task 'buildah' with steps: build, push, sbom-syft-generate, prepare-sboms, upload-sbom
Running: /Users/subratamodak/redhat_branches/PROMQL_DATA_COLLECTION_CLUSTERS_METRICS/python_venv_perfscale_mem-usage-scripts-checkin_smodak/perfscale/tools/task-mem-and-cpu-usage-scripts/.temp_wrapper.sh 10 --csv

cluster        | task     | step                    | pod_max_mem                                                     | namespace_max_mem          | component_max_mem            | application_max_mem           | mem_max_mb | mem_p95_mb | mem_p90_mb | mem_median_mb | pod_max_cpu                                                     | namespace_max_cpu          | component_max_cpu            | application_max_cpu            | cpu_max  | cpu_p95  | cpu_p90  | cpu_median
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
kflux-prd-rh02 | buildah  | step-build              | crc-binary-on-push-mqzdn-build-container-pod                    | crc-tenant                 | crc-binary                   | crc                           | 8192       | 1159       | 1115       | 894           | crc-binary-on-push-mqzdn-build-container-pod                    | crc-tenant                 | crc-binary                   | crc                            | 4435m    | 4370m    | 4011m    | 4370m     
kflux-prd-rh02 | buildah  | step-push               | crc-binary-on-push-6ss4f-build-container-pod                    | crc-tenant                 | crc-binary                   | crc                           | 536        | 78         | 31         | 4             | crc-binary-on-push-6ss4f-build-container-pod                    | crc-tenant                 | crc-binary                   | crc                            | 33m      | 0m       | 0m       | 16m       
kflux-prd-rh02 | buildah  | step-sbom-syft-generate | git-init-on-push-dxc47-build-container-pod                      | tekton-ecosystem-tenant    | git-init                     | tektoncd-git-clone            | 1258       | 345        | 254        | 4             | git-init-on-push-kh9tp-build-container-pod                      | tekton-ecosystem-tenant    | git-init                     | tektoncd-git-clone             | 80m      | 76m      | 72m      | 42m       
kflux-prd-rh02 | buildah  | step-prepare-sboms      | rhobs-thanos-opfef502acbcc000df8d73dbccfa760a22067d2087a96c-pod | rhobs-mco-tenant           | rhobs-thanos-operator-main   | rhobs-thanos-operator-main    | 10         | 4          | 5          | 4             |                                                                 | N/A                        | N/A                          | N/A                            | 0m       | 0m       | 0m       | 0m        
kflux-prd-rh02 | buildah  | step-upload-sbom        | releng-test-product-binaries-on-push-vbrjw-build-container-pod  | releng-test-product-tenant | releng-test-product-binaries | example-push-artifacts-to-cdn | 12         | 21         | 20         | 11            | releng-test-pro8abd2af0e445b220cf4f2e4c32510fa07561b89dc36f-pod | releng-test-product-tenant | releng-test-product-binaries | example-push-artifacts-to-cdn  | 2m       | 2m       | 2m       | 2m        
kflux-prd-rh03 | buildah  | step-build              | rosa-log-router80bb622bc818856d1a4ca6a5db4aacabb872f02b9192-pod | rosa-log-router-tenant     | rosa-log-router-processor-go | rosa-log-router               | 1768       | 384        | 345        | 26            | rosa-log-router80bb622bc818856d1a4ca6a5db4aacabb872f02b9192-pod | rosa-log-router-tenant     | rosa-log-router-processor-go | rosa-log-router                | 150m     | 150m     | 150m     | 150m      
kflux-prd-rh03 | buildah  | step-push               | rosa-clusters-service-main-on-push-489hk-build-container-pod    | ocm-tenant                 | rosa-clusters-service-main   | rosa-clusters-service-main    | 11         | 4          | 4          | 4             |                                                                 | N/A                        | N/A                          | N/A                            | 0m       | 0m       | 0m       | 0m        
kflux-prd-rh03 | buildah  | step-sbom-syft-generate | rosa-log-router80bb622bc818856d1a4ca6a5db4aacabb872f02b9192-pod | rosa-log-router-tenant     | rosa-log-router-processor-go | rosa-log-router               | 10         | 4          | 4          | 4             |                                                                 | N/A                        | N/A                          | N/A                            | 0m       | 0m       | 0m       | 0m        
kflux-prd-rh03 | buildah  | step-prepare-sboms      | rosa-clusters-service-main-on-push-489hk-build-container-pod    | ocm-tenant                 | rosa-clusters-service-main   | rosa-clusters-service-main    | 8          | 4          | 4          | 4             |                                                                 | N/A                        | N/A                          | N/A                            | 0m       | 0m       | 0m       | 0m        
kflux-prd-rh03 | buildah  | step-upload-sbom        | rosa-log-router80bb622bc818856d1a4ca6a5db4aacabb872f02b9192-pod | rosa-log-router-tenant     | rosa-log-router-processor-go | rosa-log-router               | 6          | 4          | 4          | 4             |                                                                 | N/A                        | N/A                          | N/A                            | 0m       | 0m       | 0m       | 0m        
stone-prd-rh01 | buildah  | step-build              | aus-cli-main-on-pull-request-4phjc-build-container-pod          | app-sre-tenant             | aus-cli-main                 | aus-cli-main                  | 8192       | 8191       | 8190       | 8180          | operator-on-pull-request-4hfvz-build-container-pod              | vp-operator-release-tenant | operator                     | patterns-operator              | 3701m    | 3632m    | 3632m    | 3621m     
stone-prd-rh01 | buildah  | step-push               | mintmaker-renovate-image-on96eb7b38522d8b49f2cc8f7160454cf7-pod | konflux-mintmaker-tenant   | mintmaker-renovate-image     | mintmaker-renovate-image      | 4096       | 1344       | 484        | 103           | mintmaker-renovate-image-on-push-wcvmq-build-container-pod      | konflux-mintmaker-tenant   | mintmaker-renovate-image     | mintmaker-renovate-image       | 516m     | 401m     | 300m     | 232m      
stone-prd-rh01 | buildah  | step-sbom-syft-generate | mintmaker-renovate-image-on-push-wcvmq-build-container-pod      | konflux-mintmaker-tenant   | mintmaker-renovate-image     | mintmaker-renovate-image      | 4096       | 1949       | 853        | 88            | mintmaker-renovate-image-on96eb7b38522d8b49f2cc8f7160454cf7-pod | konflux-mintmaker-tenant   | mintmaker-renovate-image     | mintmaker-renovate-image       | 970m     | 805m     | 480m     | 286m      
stone-prd-rh01 | buildah  | step-prepare-sboms      | aws-resource-ex4d3fd27b70752bfc14c2d9ee1d2ca52c9aa459a8aeed-pod | app-sre-tenant             | aws-resource-exporter-master | aws-resource-exporter-master  | 147        | 146        | 121        | 83            | osc-operator-bundle-on-pull-request-p65x2-build-container-pod   | ose-osc-tenant             | osc-operator-bundle          | openshift-sandboxed-containers | 58m      | 18m      | 58m      | 58m       
stone-prd-rh01 | buildah  | step-upload-sbom        | glitchtip-acceptance-main-oe03195c9e3859f2e2e2af5c1d9b0c451-pod | app-sre-tenant             | glitchtip-acceptance-main    | glitchtip-main                | 46         | 27         | 26         | 15            | notifications-backend-on-pull-request-wvrst-build-container-pod | hcc-integrations-tenant    | notifications-backend        | notifications                  | 5m       | 5m       | 5m       | 5m        
stone-prod-p02 | buildah  | step-build              | kubectl-package-internal-on-push-d6qcc-build-container-pod      | mos-lpsre-tenant           | kubectl-package-internal     | package-operator-internal     | 8192       | 4068       | 3887       | 2434          | uhc-clusters-se76ec7a2896cab6f9c166562064489be5a89260c678f3-pod | ocm-tenant                 | uhc-clusters-service-master  | uhc-clusters-service-master    | 4152m    | 4152m    | 3938m    | 3938m     
stone-prod-p02 | buildah  | step-push               | ocmci-on-pull-request-ck8fg-build-container-pod                 | ocmci-tenant               | ocmci                        | ocm-backend-tests             | 2342       | 262        | 248        | 36            | ocmci-on-pull-request-pmtsg-build-container-pod                 | ocmci-tenant               | ocmci                        | ocm-backend-tests              | 144m     | 120m     | 129m     | 63m       
stone-prod-p02 | buildah  | step-sbom-syft-generate | ocmci-on-pull-request-zkptd-build-container-pod                 | ocmci-tenant               | ocmci                        | ocm-backend-tests             | 1803       | 134        | 176        | 50            | ocmci-on-pull-request-slgql-build-container-pod                 | ocmci-tenant               | ocmci                        | ocm-backend-tests              | 81m      | 77m      | 73m      | 74m       
stone-prod-p02 | buildah  | step-prepare-sboms      | sync-controller-ui-on-pull-request-f5phh-build-container-pod    | ocp-virt-images-tenant     | sync-controller-ui           | downstream-controllers        | 50         | 8          | 8          | 7             |                                                                 | N/A                        | N/A                          | N/A                            | 0m       | 0m       | 0m       | 0m        
stone-prod-p02 | buildah  | step-upload-sbom        | fbc-4-17-on-push-mvssl-build-container-pod                      | rhdh-tenant                | fbc-4-17                     | fbc-4-17                      | 40         | 26         | 26         | 24            | ocm-ams-master-on-pull-request-b7rbm-build-container-pod        | ocm-tenant                 | ocm-ams-master               | ocm-ams-master                 | 4m       | 3m       | 3m       | 4m        


================================================================================
RESOURCE LIMIT RECOMMENDATIONS (Max + 5% Safety Margin)
================================================================================

Step: step-build
--------------------------------------------------------------------------------
  Memory: 8Gi
    - Base (Max): 8Gi
    - Coverage: 4/4 clusters

  CPU: 4600m
    - Base (Max): 4400m
    - Coverage: 4/4 clusters

Step: step-prepare-sboms
--------------------------------------------------------------------------------
  Memory: 256Mi
    - Base (Max): 256Mi
    - Coverage: 4/4 clusters

  CPU: 100m
    - Base (Max): 100m
    - Coverage: 4/4 clusters

Step: step-push
--------------------------------------------------------------------------------
  Memory: 4Gi
    - Base (Max): 4Gi
    - Coverage: 4/4 clusters

  CPU: 600m
    - Base (Max): 600m
    - Coverage: 4/4 clusters

Step: step-sbom-syft-generate
--------------------------------------------------------------------------------
  Memory: 4Gi
    - Base (Max): 4Gi
    - Coverage: 4/4 clusters

  CPU: 1100m
    - Base (Max): 1000m
    - Coverage: 4/4 clusters

Step: step-upload-sbom
--------------------------------------------------------------------------------
  Memory: 256Mi
    - Base (Max): 256Mi
    - Coverage: 4/4 clusters

  CPU: 100m
    - Base (Max): 100m
    - Coverage: 4/4 clusters


========================================================================================================================
RESOURCE LIMITS COMPARISON: CURRENT vs PROPOSED
========================================================================================================================

Step                      Current Requests               Proposed Requests              Current Limits                 Proposed Limits               
------------------------------------------------------------------------------------------------------------------------
build                     8Gi / 1                        8Gi / 4600m                    8Gi / null                     8Gi / 4600m                   
prepare-sboms             512Mi / 100m                   256Mi / 100m                   512Mi / null                   256Mi / 100m                  
push                      4Gi / 1                        4Gi / 600m                     4Gi / null                     4Gi / 600m                    
sbom-syft-generate        4Gi / 1                        4Gi / 1100m                    4Gi / null                     4Gi / 1100m                   
upload-sbom               512Mi / 100m                   256Mi / 100m                   512Mi / null                   256Mi / 100m                  

Cached recommendations to: /Users/subratamodak/redhat_branches/PROMQL_DATA_COLLECTION_CLUSTERS_METRICS/python_venv_perfscale_mem-usage-scripts-checkin_smodak/perfscale/tools/task-mem-and-cpu-usage-scripts/.analyze_cache/770eb27e198c5da6f2835079ccf58a92.json

Recommendations cached. Run with --update to apply changes.
```

* And then directly ask the tool to update the YAML file with the analyzed cached data as below (NON-DEBUG mode):
```
$ ./analyze_resource_limits.py --update --file /Users/subratamodak/redhat_branches/konflux-ci-build-definitions-forked-smodak/build-definitions-smodak/task/buildah/0.7/buildah.yaml
Loading recommendations from cache: /Users/subratamodak/redhat_branches/PROMQL_DATA_COLLECTION_CLUSTERS_METRICS/python_venv_perfscale_mem-usage-scripts-checkin_smodak/perfscale/tools/task-mem-and-cpu-usage-scripts/.analyze_cache/770eb27e198c5da6f2835079ccf58a92.json
Cache info: original_file=https://github.com/konflux-ci/build-definitions/blob/main/task/buildah/0.7/buildah.yaml, margin=5%, base=max
Updating local file: /Users/subratamodak/redhat_branches/konflux-ci-build-definitions-forked-smodak/build-definitions-smodak/task/buildah/0.7/buildah.yaml

========================================================================================================================
RESOURCE LIMITS COMPARISON: CURRENT vs PROPOSED
========================================================================================================================

Step                      Current Requests               Proposed Requests              Current Limits                 Proposed Limits               
------------------------------------------------------------------------------------------------------------------------
build                     8Gi / 1                        8Gi / 4600m                    8Gi / null                     8Gi / 4600m                   
prepare-sboms             512Mi / 100m                   256Mi / 100m                   512Mi / null                   256Mi / 100m                  
push                      4Gi / 1                        4Gi / 600m                     4Gi / null                     4Gi / 600m                    
sbom-syft-generate        4Gi / 1                        4Gi / 1100m                    4Gi / null                     4Gi / 1100m                   
upload-sbom               512Mi / 100m                   256Mi / 100m                   512Mi / null                   256Mi / 100m                  

Updated step 'upload-sbom': memory=256Mi, cpu=100m
Updated step 'prepare-sboms': memory=256Mi, cpu=100m
Updated step 'sbom-syft-generate': memory=4Gi, cpu=1100m
Updated step 'push': memory=4Gi, cpu=600m
Updated step 'build': memory=8Gi, cpu=4600m

Updated YAML file: /Users/subratamodak/redhat_branches/konflux-ci-build-definitions-forked-smodak/build-definitions-smodak/task/buildah/0.7/buildah.yaml
```

* And also in DEBUG mode:
```
$ ./analyze_resource_limits.py --update --file /Users/subratamodak/redhat_branches/konflux-ci-build-definitions-forked-smodak/build-definitions-smodak/task/buildah/0.7/buildah.yaml --debug
Loading recommendations from cache: /Users/subratamodak/redhat_branches/PROMQL_DATA_COLLECTION_CLUSTERS_METRICS/python_venv_perfscale_mem-usage-scripts-checkin_smodak/perfscale/tools/task-mem-and-cpu-usage-scripts/.analyze_cache/770eb27e198c5da6f2835079ccf58a92.json
Cache info: original_file=https://github.com/konflux-ci/build-definitions/blob/main/task/buildah/0.7/buildah.yaml, margin=5%, base=max
Updating local file: /Users/subratamodak/redhat_branches/konflux-ci-build-definitions-forked-smodak/build-definitions-smodak/task/buildah/0.7/buildah.yaml

========================================================================================================================
RESOURCE LIMITS COMPARISON: CURRENT vs PROPOSED
========================================================================================================================

Step                      Current Requests               Proposed Requests              Current Limits                 Proposed Limits               
------------------------------------------------------------------------------------------------------------------------
build                     8Gi / 1                        8Gi / 4600m                    8Gi / null                     8Gi / 4600m                   
prepare-sboms             512Mi / 100m                   256Mi / 100m                   512Mi / null                   256Mi / 100m                  
push                      4Gi / 1                        4Gi / 600m                     4Gi / null                     4Gi / 600m                    
sbom-syft-generate        4Gi / 1                        4Gi / 1100m                    4Gi / null                     4Gi / 1100m                   
upload-sbom               512Mi / 100m                   256Mi / 100m                   512Mi / null                   256Mi / 100m                  

DEBUG: Looking for steps: ['build', 'prepare-sboms', 'push', 'sbom-syft-generate', 'upload-sbom']
DEBUG: Entered steps section at line 309
DEBUG: Left steps section at line 1225: volumes:
DEBUG: Processing step 'upload-sbom' at line 1174
DEBUG: Processing step 'upload-sbom', looking for computeResources...
DEBUG: Created computeResources for step 'upload-sbom'
Updated step 'upload-sbom': memory=256Mi, cpu=100m
DEBUG: Processing step 'prepare-sboms' at line 1084
DEBUG: Processing step 'prepare-sboms', looking for computeResources...
DEBUG: Found computeResources at line 1086, indent=4 (step_content_indent=4)
DEBUG: Found limits at line 1087, indent=6
DEBUG: Updated memory in limits at line 1088: 256Mi
DEBUG: Added cpu to limits at line 1089: 100m
DEBUG: Found requests at line 1090, indent=6
DEBUG: Updated memory in requests at line 1091: 256Mi
DEBUG: Updated cpu in requests at line 1092: 100m
Updated step 'prepare-sboms': memory=256Mi, cpu=100m
DEBUG: Processing step 'sbom-syft-generate' at line 1022
DEBUG: Processing step 'sbom-syft-generate', looking for computeResources...
DEBUG: Created computeResources for step 'sbom-syft-generate'
Updated step 'sbom-syft-generate': memory=4Gi, cpu=1100m
DEBUG: Processing step 'push' at line 937
DEBUG: Processing step 'push', looking for computeResources...
DEBUG: Created computeResources for step 'push'
Updated step 'push': memory=4Gi, cpu=600m
DEBUG: Processing step 'build' at line 311
DEBUG: Processing step 'build', looking for computeResources...
DEBUG: Found computeResources at line 312, indent=4 (step_content_indent=4)
DEBUG: Found limits at line 313, indent=6
DEBUG: Updated memory in limits at line 314: 8Gi
DEBUG: Added cpu to limits at line 315: 4600m
DEBUG: Found requests at line 316, indent=6
DEBUG: Updated memory in requests at line 317: 8Gi
DEBUG: Updated cpu in requests at line 318: 4600m
Updated step 'build': memory=8Gi, cpu=4600m

Updated YAML file: /Users/subratamodak/redhat_branches/konflux-ci-build-definitions-forked-smodak/build-definitions-smodak/task/buildah/0.7/buildah.yaml
```

* Both DEBUG and NON-DEBUG mode will generate the following DIFF:
```
$ git diff
diff --git a/task/buildah/0.7/buildah.yaml b/task/buildah/0.7/buildah.yaml
index 133b1f19..e8d65f1f 100644
--- a/task/buildah/0.7/buildah.yaml
+++ b/task/buildah/0.7/buildah.yaml
@@ -312,9 +312,10 @@ spec:
     computeResources:
       limits:
         memory: 8Gi
+        cpu: 4600m
       requests:
         memory: 8Gi
-        cpu: '1'
+        cpu: 4600m
     env:
     - name: COMMIT_SHA
       value: $(params.COMMIT_SHA)
@@ -936,6 +937,13 @@ spec:
     workingDir: $(workspaces.source.path)
   - name: push
     image: quay.io/konflux-ci/buildah-task:latest@sha256:5c5eb4117983b324f932f144aa2c2df7ed508174928a423d8551c4e11f30fbd9
+    computeResources:
+      limits:
+        memory: 4Gi
+        cpu: 600m
+      requests:
+        memory: 4Gi
+        cpu: 600m
     env:
     - name: BUILDAH_FORMAT
       value: $(params.BUILDAH_FORMAT)
@@ -1021,6 +1029,13 @@ spec:
 
   - name: sbom-syft-generate
     image: quay.io/konflux-ci/task-runner:0.2.0@sha256:ba65585f5c8b0a74dc51590e95961765322427d1d62ccd4eb742ff0442291985
+    computeResources:
+      limits:
+        memory: 4Gi
+        cpu: 1100m
+      requests:
+        memory: 4Gi
+        cpu: 1100m
     # Respect Syft configuration if the user has it in the root of their repository
     # (need to set the workdir, see https://github.com/anchore/syft/issues/2465)
     workingDir: $(workspaces.source.path)/source
@@ -1085,9 +1100,10 @@ spec:
     image: quay.io/konflux-ci/mobster:1.1.0-1763042639@sha256:028dfcf2ac8b0404141550de17364bf049b0ddb35f45a24a075bc1f485a56c80
     computeResources:
       limits:
-        memory: 512Mi
+        memory: 256Mi
+        cpu: 100m
       requests:
-        memory: 512Mi
+        memory: 256Mi
         cpu: 100m
     args:
     - --additional-base-images
@@ -1173,6 +1189,13 @@ spec:
 
   - name: upload-sbom
     image: quay.io/konflux-ci/appstudio-utils:latest@sha256:74aadac7ee0ac782216730d6a4736de6da03f9fa51124674329ad717b8141f4c
+    computeResources:
+      limits:
+        memory: 256Mi
+        cpu: 100m
+      requests:
+        memory: 256Mi
+        cpu: 100m
     script: |
       #!/bin/bash
       set -euo pipefail
```

Cc: @jhutar