### PR TITLE
Fix step detection indentation in YAML update logic

### DIFF
--- a/tools/task-mem-and-cpu-usage-scripts/analyze_resource_limits.py
+++ b/tools/task-mem-and-cpu-usage-scripts/analyze_resource_limits.py
@@ -1543,8 +1543,8 @@ def update_yaml_file(yaml_path, recommendations, original_yaml, file_path_or_url
                 is_step = False
                 step_name_match = None
                 
-                # Pattern 1: "  - name: stepname"
-                if re.match(r'^\s+-\s+name:\s+', line) and line_indent == 2:
+                # Pattern 1: "    - name: stepname" (4 spaces: 2 for steps:, 2 for list item)
+                if re.match(r'^\s+-\s+name:\s+', line) and line_indent == 4:
                     is_step = True
                     step_name_match = re.search(r'name:\s+(.+)$', line)
                 # Pattern 2: "    name: stepname" (not starting with "-")
@@ -1598,8 +1598,8 @@ def update_yaml_file(yaml_path, recommendations, original_yaml, file_path_or_url
                 if search_idx < len(lines):
                     search_line = lines[search_idx]
                     line_indent = len(search_line) - len(search_line.lstrip())
-                    # Check Pattern 1: "  - name: stepname"
-                    if re.match(r'^\s+-\s+name:\s+', search_line) and line_indent == 2:
+                    # Check Pattern 1: "    - name: stepname" (4 spaces: 2 for steps:, 2 for list item)
+                    if re.match(r'^\s+-\s+name:\s+', search_line) and line_indent == 4:
                         name_match = re.search(r'name:\s+(.+)$', search_line)
                         if name_match and name_match.group(1).strip() == step_name:
                             current_step_line = search_idx
@@ -1642,8 +1642,8 @@ def update_yaml_file(yaml_path, recommendations, original_yaml, file_path_or_url
                             if 'workspaces:' in search_line or 'results:' in search_line or 'volumes:' in search_line:
                                 break
                         
-                        # Check for step name
-                        if re.match(r'^\s+-\s+name:\s+', search_line) and line_indent == 2:
+                        # Check for step name (4 spaces: 2 for steps:, 2 for list item)
+                        if re.match(r'^\s+-\s+name:\s+', search_line) and line_indent == 4:
                             name_match = re.search(r'name:\s+(.+)$', search_line)
                             if name_match and name_match.group(1).strip() == step_name:
                                 current_step_line = search_idx


### PR DESCRIPTION
The step detection regex was checking for 2-space indentation, but Tekton Task YAML step names are at 4-space indentation (2 spaces for 'steps:' + 2 spaces for list item '-'). This caused the update function to fail to find and update steps in local YAML files.

Updated all three step detection locations to check for 4-space indentation instead of 2-space. The YAML step detection logic is now consistent between analysis (using yaml.safe_load()) and update (using regex pattern matching), ensuring both phases correctly identify the same steps.

Fixes issue where --update --file <local_file> would report "No steps were updated" even when steps existed in the YAML file.

Assisted-by: Cursor-AI.