### PR TITLE
Increase timeouts and retries for busier clusters

### DIFF
--- a/tools/task-mem-and-cpu-usage-scripts/analyze_resource_limits.py
+++ b/tools/task-mem-and-cpu-usage-scripts/analyze_resource_limits.py
@@ -250,7 +250,7 @@ def check_cluster_connectivity(wrapper_path):
                 ['kubectl', 'config', 'get-contexts', '-o', 'name'],
                 capture_output=True,
                 text=True,
-                timeout=10
+                timeout=120  # 2 minutes timeout for connectivity check
             )
             if result.returncode == 0:
                 contexts = [c.strip() for c in result.stdout.strip().split('\n') if c.strip()]
@@ -270,7 +270,7 @@ def check_cluster_connectivity(wrapper_path):
                             ['kubectl', 'config', 'get-contexts', '-o', 'name'],
                             capture_output=True,
                             text=True,
-                            timeout=10
+                            timeout=120  # 2 minutes timeout for connectivity check
                         )
                         if result.returncode == 0:
                             contexts = [c.strip() for c in result.stdout.strip().split('\n') if c.strip()]
@@ -298,15 +298,15 @@ def check_cluster_connectivity(wrapper_path):
                     ['kubectl', 'config', 'use-context', ctx],
                     capture_output=True,
                     text=True,
-                    timeout=10
+                    timeout=120  # 2 minutes timeout for connectivity check
                 )
                 if result.returncode == 0:
                     # Try a simple kubectl command to verify connectivity
                     test_result = subprocess.run(
-                        ['kubectl', 'get', 'namespaces', '--request-timeout=5s'],
+                        ['kubectl', 'get', 'namespaces', '--request-timeout=2m'],
                         capture_output=True,
                         text=True,
-                        timeout=10
+                        timeout=120  # 2 minutes timeout for connectivity check
                     )
                     if test_result.returncode == 0:
                         # Use display name for report, but ctx (full context) is still used for operations
@@ -403,7 +403,7 @@ def extract_cluster_list(wrapper_path):
                 ['kubectl', 'config', 'get-contexts', '-o', 'name'],
                 capture_output=True,
                 text=True,
-                timeout=10
+                timeout=120  # 2 minutes timeout for connectivity check
             )
             if result.returncode == 0:
                 contexts = [c.strip() for c in result.stdout.strip().split('\n') if c.strip()]
@@ -421,7 +421,7 @@ def extract_cluster_list(wrapper_path):
                             ['kubectl', 'config', 'get-contexts', '-o', 'name'],
                             capture_output=True,
                             text=True,
-                            timeout=10
+                            timeout=120  # 2 minutes timeout for connectivity check
                         )
                         if result.returncode == 0:
                             contexts = [c.strip() for c in result.stdout.strip().split('\n') if c.strip()]
@@ -603,7 +603,7 @@ def process_single_cluster(cluster_ctx, temp_wrapper_path, days, steps_str, task
             text=True,
             cwd=temp_wrapper_path.parent,
             env=env,
-            timeout=3600  # 1 hour timeout per cluster
+            timeout=10800  # 3 hours timeout per cluster
         )
         
         # Clean up temporary kubeconfig
@@ -640,7 +640,7 @@ def process_single_cluster(cluster_ctx, temp_wrapper_path, days, steps_str, task
         return (cluster_ctx, '\n'.join(data_lines), None)
     
     except subprocess.TimeoutExpired:
-        return (cluster_ctx, None, "Timeout after 1 hour")
+        return (cluster_ctx, None, "Timeout after 3 hours")
     except Exception as e:
         return (cluster_ctx, None, str(e)[:200])
 

--- a/tools/task-mem-and-cpu-usage-scripts/query_prometheus_range.py
+++ b/tools/task-mem-and-cpu-usage-scripts/query_prometheus_range.py
@@ -39,6 +39,6 @@ params = {
 }
 
 t0 = time.time()
-resp = requests.get(url, headers=headers, params=params, verify=False, timeout=180)
+resp = requests.get(url, headers=headers, params=params, verify=False, timeout=900)  # 15 minutes timeout
 resp.raise_for_status()
 print(resp.text)

--- a/tools/task-mem-and-cpu-usage-scripts/wrapper_for_promql.sh
+++ b/tools/task-mem-and-cpu-usage-scripts/wrapper_for_promql.sh
@@ -28,7 +28,7 @@ query() {
     log "Query: $qry"
     local result
     local retry_count=0
-    local max_retries=2
+    local max_retries=10
     
     # Retry logic for handling transient interruptions
     while [ "$retry_count" -le "$max_retries" ]; do


### PR DESCRIPTION
Some clusters (e.g ‘stone-prd-rh01’) are busier than others and require longer wait times for queries and operations to complete. This commit increases all timeout and retry values to better handle these scenarios:

- Per-cluster wrapper execution: 1 hour -> 3 hours (10800 seconds)
- Per Prometheus query timeout: 3 minutes -> 15 minutes (900 seconds)
- Retry attempts: 3 total -> 11 total (max_retries: 2 -> 10)
- Connectivity check timeout: 10 seconds -> 2 minutes (120 seconds)
- kubectl request-timeout: 5s -> 2m

These changes ensure that data collection can complete successfully even when clusters are under heavy load or experiencing network delays.

Assisted-by: Cursor-AI.