### PR TITLE
Fix numeric sorting in HTML tables by removing quotes from cell values

### DIFF
--- a/tools/tasks-and-steps-resource-analyzer/analyze_resource_limits.py
+++ b/tools/tasks-and-steps-resource-analyzer/analyze_resource_limits.py
@@ -1647,7 +1647,9 @@ def save_csv_to_html(csv_data, task_name, timestamp_str):
     
     # Add headers with click handlers
     for i, header in enumerate(headers):
-        html_content += f'                <th onclick="sortTable({i})">{header}</th>\n'
+        # Strip quotes from header names for cleaner display
+        header_cleaned = header.strip().strip('"').strip("'")
+        html_content += f'                <th onclick="sortTable({i})">{header_cleaned}</th>\n'
     
     html_content += """            </tr>
         </thead>
@@ -1658,8 +1660,11 @@ def save_csv_to_html(csv_data, task_name, timestamp_str):
     for row in data_rows:
         html_content += "            <tr>\n"
         for cell in row:
+            # Strip quotes from cell value for proper numeric sorting
+            # CSV data has quotes around values, but HTML should display without quotes
+            cell_cleaned = str(cell).strip().strip('"').strip("'")
             # Escape HTML special characters
-            cell_escaped = str(cell).replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;').replace('"', '&quot;')
+            cell_escaped = cell_cleaned.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;').replace('"', '&quot;')
             html_content += f"                <td>{cell_escaped}</td>\n"
         html_content += "            </tr>\n"
     


### PR DESCRIPTION
Strip quotes from CSV cell values when generating HTML to enable proper numeric sorting. Quotes are preserved in CSV output but removed in HTML display for correct sorting behavior.

Changes:
- Updated save_csv_to_html() to strip quotes from cell values before inserting into HTML table
- Updated header processing to strip quotes for cleaner display
- Numeric columns (e.g., mem_max_mb, mem_p95_mb) now sort correctly instead of alphabetically

This fixes the issue where numeric values wrapped in quotes were being sorted as strings (e.g., "12288" vs "16390") instead of numerically.

Assisted-by: Cursor-AI.