### PR TITLE
Exclude ephemeral namespaces from OOM/CrashLoopBackOff scans on EaaS clusters

### DIFF
--- a/tools/oomkill-and-crashloopbackoff-detector/README.md
+++ b/tools/oomkill-and-crashloopbackoff-detector/README.md
@@ -27,6 +27,10 @@ A high-performance, parallel OOMKilled / CrashLoopBackOff detector for OpenShift
   - **JSON** - Structured automation input
   - **HTML** - Standalone visual report (open in browser)
   - **TABLE** - Human-readable text table
+- **Automatic ephemeral namespace exclusion** on EaaS clusters
+  - Excludes ephemeral test and cluster namespaces by default to avoid false positives
+  - Ephemeral cluster namespaces: `clusters-<uuid>` pattern
+  - Ephemeral test namespaces: `test-*`, `e2e-*`, `ephemeral-*`, `ci-*`, etc.
 - Colorized terminal output
 
 ---
@@ -308,6 +312,23 @@ Filter events by time range (default: 1 day):
 - `M` = months (30 days, e.g., `1M`, `2M`)
 
 ### Namespace Filtering
+
+#### Ephemeral Namespace Exclusion (Default on EaaS Clusters)
+
+By default, the tool automatically excludes ephemeral test and cluster namespaces
+to avoid false positives from temporary test environments on EaaS clusters.
+
+**Ephemeral namespaces that are excluded by default:**
+- **Ephemeral cluster namespaces**: `clusters-<uuid>` pattern
+  - Example: `clusters-4e52ba17-c17b-4f35-b7e0-0215e63678a0`
+- **Ephemeral test namespaces**: Common test patterns
+  - `test-*`, `e2e-*`, `ephemeral-*`, `ci-*`, `pr-*`, `temp-*`, `tmp-*`
+  - Namespaces ending with `-test`, `-e2e`, `-ephemeral`
+
+To include ephemeral namespaces in the scan:
+```bash
+./oc_get_ooms.py --include-ephemeral
+```
 
 #### Include only specific namespaces
 ```bash

--- a/tools/oomkill-and-crashloopbackoff-detector/oom_logs_and_desc_bundle_generator
+++ b/tools/oomkill-and-crashloopbackoff-detector/oom_logs_and_desc_bundle_generator
@@ -5,7 +5,8 @@ set -e  # Exit on error
 # Default values
 POD_NAME=""
 TYPE=""
-CSV_FILE="oom_results.csv"
+CSV_FILE="output/oom_results.csv"
+OUTPUT_DIR="output"
 
 # Function to print help
 print_help() {
@@ -14,11 +15,11 @@ Usage: $0 -p POD_NAME -t TYPE [OPTIONS]
    or: $0 --pod-name POD_NAME --type TYPE [OPTIONS]
 
 Required Arguments:
-  -p, --pod-name POD_NAME    Name of the pod to bundle (must exist in oom_results.csv)
+  -p, --pod-name POD_NAME    Name of the pod to bundle (must exist in output/oom_results.csv)
   -t, --type TYPE            Type of issue: OOMKilled or CrashLoopBackOff (case-insensitive)
 
 Options:
-  -c, --csv-file FILE        Path to oom_results.csv (default: oom_results.csv)
+  -c, --csv-file FILE        Path to oom_results.csv (default: output/oom_results.csv)
   -h, --help                 Show this help message
 
 Examples:
@@ -129,6 +130,9 @@ fi
 # All validations passed - proceed with the script
 set -x
 
+# Ensure output directory exists
+mkdir -p "${OUTPUT_DIR}"
+
 DATE="`date +%Y-%m-%d`"
 TYPE1="OOMKilled"
 TYPE2="CrashLoopBackOff"
@@ -163,10 +167,11 @@ ls -l /private/tmp/${DATE}/
 
 du -sh /private/tmp/${DATE}/${TYPE}.tgz
 
-# Copy to current directory with descriptive name
-cp /private/tmp/${DATE}/${TYPE}.tgz .
-cp ${TYPE}.tgz ${TYPE}-${POD_NAME}.tgz
+# Copy to output directory with descriptive name
+cp /private/tmp/${DATE}/${TYPE}.tgz "${OUTPUT_DIR}/"
+cp "${OUTPUT_DIR}/${TYPE}.tgz" "${OUTPUT_DIR}/${TYPE}-${POD_NAME}.tgz"
 
-ls -ltr 
+echo "Bundle files saved to ${OUTPUT_DIR}/ directory:"
+ls -ltr "${OUTPUT_DIR}/${TYPE}"*.tgz 2>/dev/null || ls -ltr "${OUTPUT_DIR}/" | grep "${TYPE}"
 
 set +x


### PR DESCRIPTION
Automatically exclude ephemeral test and cluster namespaces by default to prevent false positives from temporary test environments on EaaS clusters.

This addresses review feedback where OOMKilled issues were reported for pods running in ephemeral namespaces (e.g., catalog-operator and certified-operators-catalog pods in cryptic clusters-* namespaces).

Ephemeral namespace detection:
- Ephemeral cluster namespaces: clusters-<uuid> pattern (e.g., clusters-4e52ba17-c17b-4f35-b7e0-0215e63678a0)
- Ephemeral test namespaces: test-*, e2e-*, ephemeral-*, ci-*, pr-*, temp-*, tmp-*, and namespaces ending with -test, -e2e, -ephemeral

Changes:
- Add is_ephemeral_namespace() function to detect ephemeral namespaces
- Update get_namespaces_for_context() to exclude ephemeral namespaces by default (exclude_ephemeral=True)
- Add --include-ephemeral flag to override default behavior and include ephemeral namespaces in scans
- Update query_context() and run_batches() to pass exclude_ephemeral parameter through the call chain
- Display ephemeral exclusion status in main() output
- Update README.md with documentation on ephemeral namespace exclusion

By default, ephemeral namespaces are excluded on all clusters. Use --include-ephemeral flag if you need to scan ephemeral namespaces for debugging or testing purposes.

Assisted-by: Cursor-AI.