### PR TITLE
Fix PromQL bug and update resource rounding standards

### DIFF
--- a/tools/tasks-and-steps-resource-analyzer/analyze_resource_limits.py
+++ b/tools/tasks-and-steps-resource-analyzer/analyze_resource_limits.py
@@ -1089,24 +1089,24 @@ def parse_csv_data(csv_text):
 def round_memory_to_standard(mb):
     """Round memory to standard Kubernetes values.
     
-    For values < 1Gi: round to increments of 256Mi (256Mi, 512Mi, 768Mi)
+    For values < 1Gi: round to increments of 64Mi (64Mi, 128Mi, 192Mi, 256Mi, etc.)
     For values >= 1Gi: round to whole Gi values (1Gi, 2Gi, 3Gi, etc.)
     
-    Minimum value: 256Mi (to account for sparse monitoring data)
-    Rounds to nearest, but ensures we don't go below the recommended value.
+    Minimum value: 64Mi (allows fine granularity while being more standard than 32Mi)
+    Always rounds up to ensure we don't go below the recommended value.
     """
     mb = float(mb)
     
-    # Enforce minimum of 256Mi
-    MIN_MEMORY_MB = 256
+    # Enforce minimum of 64Mi (allows fine granularity while being more standard than 32Mi)
+    MIN_MEMORY_MB = 64
     
     if mb < MIN_MEMORY_MB:
         mb = MIN_MEMORY_MB
     
     if mb < 1024:
-        # Round UP to next highest increment of 256Mi
-        # Using +255 ensures we always round up (e.g., 300Mi -> 512Mi, not 256Mi)
-        rounded = ((int(mb) + 255) // 256) * 256
+        # Round UP to next highest increment of 64Mi
+        # Using +63 ensures we always round up (e.g., 65Mi -> 128Mi, not 64Mi)
+        rounded = ((int(mb) + 63) // 64) * 64
         
         # Ensure minimum
         if rounded < MIN_MEMORY_MB:
@@ -1139,22 +1139,22 @@ def mb_to_kubernetes(mb):
 def round_cpu_to_standard(cores):
     """Round CPU to standard Kubernetes values.
     
-    Rounds UP to next highest increment of 100m (100m, 200m, 300m, etc.)
-    Minimum value: 100m (to account for sparse monitoring data)
+    Rounds UP to next highest increment of 50m (50m, 100m, 150m, 200m, etc.)
+    Minimum value: 50m (allows finer granularity)
     Always rounds up to ensure we don't go below the recommended value.
     """
     cores = float(cores)
     millicores = cores * 1000
     
-    # Enforce minimum of 100m
-    MIN_CPU_MILLICORES = 100
+    # Enforce minimum of 50m (allows finer granularity)
+    MIN_CPU_MILLICORES = 50
     
     if millicores < MIN_CPU_MILLICORES:
         millicores = MIN_CPU_MILLICORES
     
-    # Round UP to next highest increment of 100m
-    # Using +99 ensures we always round up (e.g., 243m -> 300m, not 200m)
-    rounded_m = ((int(millicores) + 99) // 100) * 100
+    # Round UP to next highest increment of 50m
+    # Using +49 ensures we always round up (e.g., 51m -> 100m, not 50m)
+    rounded_m = ((int(millicores) + 49) // 50) * 50
     
     # Ensure minimum
     if rounded_m < MIN_CPU_MILLICORES:

--- a/tools/tasks-and-steps-resource-analyzer/wrapper_for_promql.sh
+++ b/tools/tasks-and-steps-resource-analyzer/wrapper_for_promql.sh
@@ -176,8 +176,10 @@ while [ "$start" -lt "$total" ]; do
     
     # ------------------------------------------------------------
     # MEMORY - Max
+    # Use container_memory_working_set_bytes (actual usage) instead of 
+    # container_memory_max_usage_bytes (which reflects limits, not actual usage)
     # ------------------------------------------------------------
-    max_query="max_over_time(container_memory_max_usage_bytes{container=\"$STEP\",pod=~\"($batch_pods)\",namespace=~\".*-tenant\"}[$RANGE])"
+    max_query="max_over_time(container_memory_working_set_bytes{container=\"$STEP\",pod=~\"($batch_pods)\",namespace=~\".*-tenant\"}[$RANGE])"
     max_json="$(query "$max_query")"
     
     max_entry="$(echo "$max_json" | jq -r '


### PR DESCRIPTION
Fix critical bug in memory metric collection and update rounding standards to provide finer granularity while maintaining Kubernetes best practices.

PROMQL BUG FIX:
---------------
- Changed max memory query from container_memory_max_usage_bytes to container_memory_working_set_bytes
- container_memory_max_usage_bytes reflects memory limits, not actual usage, causing false max values (e.g., 10240 MB / 10 GiB) when containers had high limits but low actual usage
- container_memory_working_set_bytes reflects actual memory usage, matching the metric used for percentiles (p95, p90, median)
- This fix eliminates false 10240 MB values and ensures recommendations are based on actual observed usage patterns

VERIFICATION:
- Before fix: step-push showed 10240 MB (10 GiB) max, but actual usage was ~735 MB
- After fix: step-push correctly shows 735 MB max, rounding to 768Mi
- Before fix: step-sbom-syft-generate showed 10240 MB (10 GiB) max, but actual usage was ~2989 MB
- After fix: step-sbom-syft-generate correctly shows 2989 MB max, rounding to 3Gi

ROUNDING STANDARDS UPDATE:
-------------------------
- Memory: Changed from 256Mi minimum/increments to 64Mi minimum/increments
  * Allows finer granularity (64Mi, 128Mi, 192Mi, 256Mi, etc.)
  * More standard than 32Mi while still providing fine-grained recommendations
  * Examples: 181 MB → 192Mi (3 × 64Mi), 735 MB → 768Mi (12 × 64Mi)

- CPU: Changed from 100m minimum/increments to 50m minimum/increments
  * Allows finer granularity (50m, 100m, 150m, 200m, etc.)
  * Provides more precise recommendations for low-CPU workloads
  * Examples: 0.4599 cores → 500m (10 × 50m), 1.1529 cores → 1200m (24 × 50m)

TECHNICAL CHANGES:
------------------
- wrapper_for_promql.sh: Updated max memory query to use container_memory_working_set_bytes instead of container_memory_max_usage_bytes
- analyze_resource_limits.py:
  * Updated round_memory_to_standard(): Changed from 256Mi to 64Mi increments
  * Updated round_cpu_to_standard(): Changed from 100m to 50m increments
  * Updated function docstrings to reflect new rounding standards

DOCUMENTATION:
-------------
- Updated README.md:
  * Updated PromQL query description to reflect container_memory_working_set_bytes usage
  * Updated rounding rules section with new 64Mi/50m standards
  * Added technical notes explaining why we use working_set_bytes (actual usage vs limits)
  * Updated example outputs to reflect new rounding values
  * Updated "Smart Rounding" description

BENEFITS:
---------
- Eliminates false high memory values caused by using limit-based metrics
- Recommendations now accurately reflect actual usage patterns
- Finer granularity allows more precise resource recommendations
- Better alignment with actual observed usage (e.g., 3-4 GiB range instead of false 10 GiB)
- More appropriate recommendations for low-resource workloads

Files Changed:
- wrapper_for_promql.sh: Fixed PromQL query for max memory
- analyze_resource_limits.py: Updated rounding functions and standards
- README.md: Updated documentation to reflect changes

Assisted-by: Cursor-AI.