### PR TITLE
Add per-pod tarballs after run; fix Jenkins remote flow; doc updates

### DIFF
--- a/tools/oomkill-and-crashloopbackoff-detector/README.md
+++ b/tools/oomkill-and-crashloopbackoff-detector/README.md
@@ -29,7 +29,7 @@ A high-performance, parallel OOMKilled / CrashLoopBackOff detector for OpenShift
   - **HTML** - Standalone visual report (open in browser)
   - **TABLE** - Human-readable text table
 - Enriches each finding with **Application** and **Component** from pod `metadata.labels` (e.g. `appstudio.openshift.io/application`, `tekton.dev/pipelineTask`) so you can see which app/component a pod belongs to—no extra API calls.
-- At the **end of each run**, prints a **per-pod summary** (same format as `oom_logs_and_desc_bundle_generator`): for each pod that had OOMKilled or CrashLoopBackOff in this run, one "Report for pod: …" block with instance counts per (type, cluster, namespace). Optional `-c` / `--codeowners-dir` shows namespace owner (name + email via `glab`).
+- At the **end of each run**, prints a **per-pod summary** (same format as `oom_logs_and_desc_bundle_generator`): for each pod that had OOMKilled or CrashLoopBackOff in this run, one "Report for pod: …" block with instance counts per (type, cluster, namespace). Optional `-c` / `--codeowners-dir` shows namespace owner (name + email via `glab`). Then **generates per-pod tarballs** for each reported pod (use `--no-tarballs` to skip).
 - Colorized terminal output
 
 ---
@@ -253,7 +253,7 @@ CrashLoopBackOff: 1 instance(s) on 03-Feb-2026, Namespace: openshift-machine-con
 ==============================================
 ```
 
-- **No tarballs** are created by `oc_get_ooms.py`; use `oom_logs_and_desc_bundle_generator -p <pod_name>` to generate pod-specific tarballs when needed. `oc_get_ooms.py` creates the `output/tarballs/` subdirectory so Jenkins or downstream runs can write tarballs there without cluttering the main output dir.
+- **Per-pod tarballs:** After the per-pod summary, `oc_get_ooms.py` automatically runs `oom_logs_and_desc_bundle_generator` for each reported pod (using a match string derived from actual pod names so the bundle generator finds CSV rows). Tarballs are written under `output/tarballs/`. Use **`--no-tarballs`** to skip this step.
 - To show **namespace owner** (name + email from CODEOWNERS + GitLab) in each line, pass **`-c` / `--codeowners-dir`** with the path to konflux-release-data (directory containing `CODEOWNERS` and `staging/CODEOWNERS`). Requires `glab` to be installed and logged in.
 
 ```bash
@@ -598,8 +598,8 @@ Backed up 4 existing file(s):
 
 ### Per-pod summary from `oc_get_ooms.py` vs bundle generator
 
-- **`oc_get_ooms.py`** prints a per-pod summary **at the end of every run**: one "Report for pod: …" block per pod that had OOM/CrashLoop in that run. It uses only the data from the current run (one date = run date). No tarballs are created.
-- **`oom_logs_and_desc_bundle_generator`** is used when you want **date-wise** reports and **tarballs** for a **specific pod**: it scans all date-wise CSVs in `output/` and builds one tarball per (type, date) for that pod.
+- **`oc_get_ooms.py`** prints a per-pod summary **at the end of every run** (one "Report for pod: …" block per pod that had OOM/CrashLoop in that run), then **generates tarballs** for each of those pods by invoking `oom_logs_and_desc_bundle_generator` with a **match string** (longest common prefix of actual pod names) so the bundle generator finds the right rows in the CSV. Use `--no-tarballs` to skip tarball generation.
+- **`oom_logs_and_desc_bundle_generator`** is used when you want **date-wise** reports and **tarballs** for a **specific pod** (e.g. run manually for one pod): it scans all date-wise CSVs in `output/` and builds one tarball per (type, date) for that pod. It matches the CSV pod column by **substring** (pass a literal that appears in the pod name, not the display name with `*`).
 
 ### Date-wise bundle generator (`oom_logs_and_desc_bundle_generator`)
 
@@ -612,7 +612,7 @@ The script `oom_logs_and_desc_bundle_generator` builds **date-specific** log/des
 
 **Options:**
 - **`-p` / `--pod-name`** (required): Pod name or substring to match (e.g. `oom-stress-retry` matches `oom-stress-retry-mp275`).
-- **`-d` / `--output-dir`**: Directory containing date-wise CSVs (default: `output`). If it starts with `http://` or `https://`, it is treated as a **URL**: the script downloads the directory (by following HTML index listings), runs the generator in a temp dir, then uploads new tarballs to `<URL>/tarballs/`. **Auth:** set `REMOTE_USER` and `REMOTE_TOKEN` (or `JENKINS_USER` and `JENKINS_TOKEN`), or use `~/.netrc`. The server must expose directory listings and support PUT for uploads (e.g. Jenkins workspace).
+- **`-d` / `--output-dir`**: Directory containing date-wise CSVs (default: `output`). If it starts with `http://` or `https://`, it is treated as a **URL**: the script downloads the directory (by following HTML index listings), runs the generator in a temp dir, then uploads new tarballs to `<URL>/tarballs/`. **Auth:** set `REMOTE_TOKEN` only (Cookie auth, e.g. Jenkins session), or `REMOTE_USER` and `REMOTE_TOKEN`, or `JENKINS_USER` and `JENKINS_TOKEN`, or use `~/.netrc`. The server must expose directory listings and support PUT for uploads (e.g. Jenkins workspace). When using a URL, download/upload details are written to **`tarball_generation.log`** in the current directory; stdout shows a single-line progress. Parallel downloads use **20** workers by default (edit `DOWNLOAD_PARALLEL_JOBS` in the script to change).
 - **`-c` / `--codeowners-dir`**: Path to konflux-release-data (contains `CODEOWNERS`, `staging/CODEOWNERS`). If **not** set, the script clones `git@gitlab.cee.redhat.com:releng/konflux-release-data.git` to a temp dir, uses it for owner lookup, then deletes it.
 
 **Behavior:**
@@ -637,14 +637,22 @@ CrashLoopBackOff: 0 instances (no occurrences in date-wise CSVs)
 
 **Requirements for owner name + email:** `git` (and SSH access to gitlab.cee.redhat.com) and `glab` (logged in). If clone or glab fails, the report still runs; owner part is omitted or shows "(no CODEOWNERS repo available)".
 
+**Remote (URL) mode — short summary:**
+- **Auth:** `REMOTE_TOKEN` only (Cookie) is enough for many Jenkins setups; no `REMOTE_USER` required. Or use `REMOTE_USER`+`REMOTE_TOKEN` or `JENKINS_USER`+`JENKINS_TOKEN`.
+- **Log:** Download/upload details go to `tarball_generation.log` in the current directory; stdout shows a single-line progress (e.g. `Progress: 480/480 files (done)`).
+- **Parallel downloads:** Default 20 workers; edit `DOWNLOAD_PARALLEL_JOBS` in the script to change.
+- **Path handling:** The script normalizes Jenkins-style hrefs (base path stripped) to avoid duplicate-path warnings, and rewrites CSV artifact paths to local paths so tarballs are built from downloaded files.
+- **Upload:** Uses HTTP PUT. If the server returns **405 Method Not Allowed**, uploads will fail (server does not allow PUT); the rest of the run (download, report, tarball creation) still succeeds.
+
 **Examples:**
 ```bash
 ./oom_logs_and_desc_bundle_generator -p oom-stress-retry
 ./oom_logs_and_desc_bundle_generator -p loki-ingester-zone-a-0 -d output
 ./oom_logs_and_desc_bundle_generator -p image-controller-image-pruner-cronjob -c /path/to/konflux-release-data
 # URL mode (e.g. Jenkins artifact URL): download → generate → upload tarballs to URL/tarballs/
-export REMOTE_USER=myuser REMOTE_TOKEN=mytoken
-./oom_logs_and_desc_bundle_generator -p my-pod -d https://jenkins.example.com/job/oom-reports/ws/artifacts
+# REMOTE_TOKEN only (Cookie) is enough for many Jenkins setups:
+REMOTE_TOKEN='your-cookie-or-token' ./oom_logs_and_desc_bundle_generator -p my-pod -d https://jenkins.example.com/job/oom-reports/ws/artifacts
+# Or: export REMOTE_USER=myuser REMOTE_TOKEN=mytoken
 ```
 
 ---
@@ -656,13 +664,15 @@ export REMOTE_USER=myuser REMOTE_TOKEN=mytoken
 **Recent Enhancements (including Feb 12, 2026):**
 - **Artifact path:** Pod logs and description files are saved under `output/logs_and_description_files/<cluster>/` (same on Mac and Jenkins). One-time migration from `/private/tmp/` is available via `migrate_artifacts_from_private_tmp.py`.
 - **Cluster connectivity:** No user confirmation prompt. The tool checks connectivity to all clusters, prints a report, then proceeds automatically if at least one cluster is connected, or aborts if none are.
-- **Constant Parallelism**: Maintains optimal resource utilization across all clusters
-- **Performance Optimized**: Single event API call per namespace (3x faster)
-- **Comprehensive Detection**: Events + pod status checks ensure no OOM/CrashLoop pods are missed
-- **Time Range Filtering**: Focus on recent events with configurable lookback window
-- **Multi-Format Output**: CSV, JSON, HTML, and TABLE formats for maximum flexibility
-- **HTML Reports**: Standalone visual reports with clickable artifact links
-- **Consistent Output**: All formats are synchronized and include metadata
+- **Constant Parallelism**: Maintains optimal resource utilization across all clusters.
+- **Performance Optimized**: Single event API call per namespace (3x faster).
+- **Comprehensive Detection**: Events + pod status checks ensure no OOM/CrashLoop pods are missed.
+- **Time Range Filtering**: Focus on recent events with configurable lookback window.
+- **Multi-Format Output**: CSV, JSON, HTML, and TABLE formats for maximum flexibility.
+- **HTML Reports**: Standalone visual reports with clickable artifact links.
+- **Consistent Output**: All formats are synchronized and include metadata.
+- **Automatic per-pod tarballs:** After the per-pod summary, `oc_get_ooms.py` generates date-wise tarballs for each reported pod (via `oom_logs_and_desc_bundle_generator`), using a match string (longest common prefix of actual pod names) so the bundle generator finds CSV rows. Use `--no-tarballs` to skip.
+- **Bundle generator (remote mode):** `REMOTE_TOKEN`-only Cookie auth; `tarball_generation.log` for details; single-line download progress; parallel downloads (`DOWNLOAD_PARALLEL_JOBS`); path normalization and CSV path rewriting for Jenkins-style URLs. Upload requires server to accept PUT (405 = not supported).
 
 ---
 
@@ -677,6 +687,8 @@ Adapt as needed.
 
 The following enhancements are **intentionally planned** and align with the current architecture.
 Most can be added incrementally without redesigning the tool.
+
+**Possible future: Logs from Splunk when cluster logs are gone.** When the tool runs on a 24h (or longer) interval, pod logs for older crashed containers may no longer be available from the cluster (`oc logs --previous` only reaches the most recent previous instance). Logs may be archived in Splunk (or, for TaskRuns, in kubearchive). A future option could be to fall back to fetching relevant logs from Splunk when cluster logs are missing. For Splunk API usage (including static tokens / service accounts for automation), see [Splunk API usage](https://source.redhat.com/departments/strategy_and_operations/it/splunk/splunk_wiki/splunk_api_usage). This is noted here as an idea for the future if the team decides to pursue it.
 
 ---
 

--- a/tools/oomkill-and-crashloopbackoff-detector/oc_get_ooms.py
+++ b/tools/oomkill-and-crashloopbackoff-detector/oc_get_ooms.py
@@ -1985,6 +1985,29 @@ def _pod_base_name(full_name: str) -> str:
     return result if result else full_name
 
 
+def _match_string_for_bundle_generator(pod_names: List[str]) -> str:
+    """
+    Return a substring that matches all given pod names in CSV column 3.
+    oom_logs_and_desc_bundle_generator uses index($3, pod) > 0, so we need a
+    literal string that appears in the actual pod names (not the display base name
+    with asterisks). Use longest common prefix so we match exactly this group.
+    """
+    if not pod_names:
+        return ""
+    if len(pod_names) == 1:
+        return pod_names[0]
+    prefix = pod_names[0]
+    for name in pod_names[1:]:
+        i = 0
+        for a, b in zip(prefix, name):
+            if a != b:
+                break
+            i += 1
+        prefix = prefix[:i]
+    # Strip trailing hyphen so we match "apiserver-69cc49fdf9" in "apiserver-69cc49fdf9-cbnj4"
+    return prefix.rstrip("-") if prefix else pod_names[0]
+
+
 def _date_from_timestamped_csv_basename(basename: str) -> Optional[str]:
     """Extract DD-Mon-YYYY from oom_results_DD-Mon-YYYY_*.csv. Returns None if not matched."""
     if not basename.startswith("oom_results_") or not basename.endswith(".csv"):
@@ -2453,9 +2476,14 @@ Output:
   - oom_results.html       Standalone HTML report (open in browser)
   At the end, a per-pod summary is printed (same format as
   oom_logs_and_desc_bundle_generator); use -c to include CODEOWNERS owners.
+  Then, for each pod in the summary, date-wise tarballs are generated (same as
+  running oom_logs_and_desc_bundle_generator -p <pod> -d <output> for each pod).
+  Use --no-tarballs to skip tarball generation.
 
   -c, --codeowners-dir DIR  Path to konflux-release-data (CODEOWNERS, staging/CODEOWNERS).
                             If set, per-pod summary shows namespace owner (name + email via glab).
+
+  --no-tarballs            Do not generate per-pod tarballs after the run (default: generate tarballs).
 
 Debug & Troubleshooting:
   -v, --verbose            Show which namespaces are scanned or skipped (ephemeral/include/exclude)
@@ -2551,6 +2579,7 @@ def parse_args(
     codeowners_dir: Optional[str] = None
     print_summary_from_dir: Optional[str] = None
     output_dir_str = "output"
+    no_tarballs = "--no-tarballs" in args
 
     if "--output" in args:
         i = args.index("--output")
@@ -2747,6 +2776,7 @@ def parse_args(
         codeowners_dir,
         print_summary_from_dir,
         output_dir_str,
+        no_tarballs,
     )
 
 
@@ -2778,6 +2808,7 @@ def main() -> None:
         codeowners_dir,
         print_summary_from_dir,
         output_dir_str,
+        no_tarballs,
     ) = parse_args(sys.argv[1:])
 
     # --print-summary-from-dir: print summary and generate HTML from existing CSVs (no cluster run)
@@ -2979,6 +3010,37 @@ def main() -> None:
         output_dir=output_dir,
         codeowners_dir=codeowners_path,
     )
+
+    # Generate per-pod tarballs (same as oom_logs_and_desc_bundle_generator -p <pod> -d <output> for each pod)
+    # The bundle generator matches CSV pod column by substring; we must pass a literal that appears in
+    # actual pod names (not the display base name like "apiserver-*" which has asterisks).
+    if not no_tarballs and current_run_rows:
+        script_dir = Path(__file__).resolve().parent
+        bundle_gen = script_dir / "oom_logs_and_desc_bundle_generator"
+        # Group full pod names by display base_name, then compute a match string (longest common prefix)
+        base_to_pods: Dict[str, List[str]] = defaultdict(list)
+        for row in current_run_rows:
+            base_to_pods[_pod_base_name(row["pod"])].append(row["pod"])
+        if bundle_gen.is_file():
+            print()
+            print(color(f"Generating tarballs for {len(base_to_pods)} pod(s) ...", BLUE))
+            for base_name in sorted(base_to_pods.keys()):
+                pod_names = base_to_pods[base_name]
+                match_str = _match_string_for_bundle_generator(pod_names)
+                if not match_str:
+                    continue
+                cmd = [
+                    str(bundle_gen),
+                    "-p", match_str,
+                    "-d", str(output_dir),
+                ]
+                if codeowners_path is not None and codeowners_path.is_dir():
+                    cmd.extend(["-c", str(codeowners_path)])
+                rc = subprocess.run(cmd, cwd=str(script_dir))
+                if rc.returncode != 0:
+                    print(color(f"  Warning: tarball generation for pod '{base_name}' exited with {rc.returncode}", YELLOW))
+        else:
+            print(color(f"  Skipping tarballs: {bundle_gen} not found", YELLOW))
 
 
 if __name__ == "__main__":

--- a/tools/oomkill-and-crashloopbackoff-detector/oom_logs_and_desc_bundle_generator
+++ b/tools/oomkill-and-crashloopbackoff-detector/oom_logs_and_desc_bundle_generator
@@ -9,6 +9,12 @@ CODEOWNERS_DIR=""      # If set, look up namespace owners from CODEOWNERS and Gi
 CODEOWNERS_TEMP_DIR="" # If we clone konflux-release-data, we remove this on exit
 KONFLUX_RELEASE_DATA_REPO="git@gitlab.cee.redhat.com:releng/konflux-release-data.git"
 
+# Parallelism for remote download (edit this variable to change number of concurrent downloads)
+DOWNLOAD_PARALLEL_JOBS=20
+
+# Log file for download/upload details (in current directory when using URL mode)
+TARBALL_GENERATION_LOG="tarball_generation.log"
+
 # Ordinal suffix for day: 1st, 2nd, 3rd, 4th, ..., 11th, 21st, 22nd, 23rd, etc.
 day_ordinal() {
     local d="$1"
@@ -85,23 +91,36 @@ get_user_display() {
     fi
 }
 
-# Build curl auth options from env: REMOTE_USER/REMOTE_TOKEN or JENKINS_USER/JENKINS_TOKEN; else .netrc is used by curl
+# Build curl auth options from env: REMOTE_TOKEN only (Cookie), REMOTE_USER+REMOTE_TOKEN (Basic), or JENKINS_*; else .netrc
 build_curl_auth() {
     CURL_AUTH_ARRAY=()
     if [[ -n "${REMOTE_USER:-}" && -n "${REMOTE_TOKEN:-}" ]]; then
         CURL_AUTH_ARRAY=(-u "${REMOTE_USER}:${REMOTE_TOKEN}")
+    elif [[ -n "${REMOTE_TOKEN:-}" ]]; then
+        # Token-only: use as Cookie (e.g. Jenkins session) so REMOTE_USER is not required
+        CURL_AUTH_ARRAY=(-H "Cookie: ${REMOTE_TOKEN}")
     elif [[ -n "${JENKINS_USER:-}" && -n "${JENKINS_TOKEN:-}" ]]; then
         CURL_AUTH_ARRAY=(-u "${JENKINS_USER}:${JENKINS_TOKEN}")
     fi
 }
 
-# Recursively download directory listing from base_url/path_prefix into dest_dir.
-# base_url has no trailing slash; path_prefix may be "" or "subdir/" (trailing slash for dirs).
-download_directory_from_url() {
+# Extract path part from URL (e.g. https://host/workspace/ARTIFACTS/StoneSoupOOMDetector -> workspace/ARTIFACTS/StoneSoupOOMDetector)
+# so we can normalize hrefs that repeat this path and avoid wrong recursion.
+get_base_path_from_url() {
+    local url="$1"
+    local path
+    path="${url#*://}"       # strip scheme
+    path="${path#*/}"        # strip host
+    path="${path%%\?*}"      # strip query
+    echo "$path"
+}
+
+# List-only pass: recurse and print relative path of each file to stdout (one per line). Used to feed parallel download.
+list_remote_files() {
     local base_url="$1"
     local path_prefix="$2"
-    local dest_dir="$3"
-    local full_url index_html dir_path
+    local base_path_opt="${3:-}"
+    local full_url index_html norm
     if [[ -z "$path_prefix" ]]; then
         full_url="${base_url}/"
     else
@@ -110,7 +129,6 @@ download_directory_from_url() {
     index_html=$(mktemp 2>/dev/null || mktemp -t oom_index)
     trap 'rm -f "$index_html"' RETURN
     if ! curl -s -f "${CURL_AUTH_ARRAY[@]}" -o "$index_html" "$full_url"; then
-        echo "Warning: could not fetch directory listing: $full_url" >&2
         return 0
     fi
     grep -oE 'href="[^"]*"' "$index_html" 2>/dev/null | sed 's/^href="//;s/"$//' | while IFS= read -r href; do
@@ -120,47 +138,95 @@ download_directory_from_url() {
         [[ "$href" == "#" || "$href" == "?"* || "$href" == "javascript:"* ]] && continue
         [[ "$href" == "../"* || "$href" == ".." ]] && continue
         [[ "$href" == "http://"* || "$href" == "https://"* ]] && continue
-        if [[ "$href" == */ ]]; then
-            download_directory_from_url "$base_url" "${path_prefix}${href}" "$dest_dir"
-        else
-            dir_path="${dest_dir}/${path_prefix}"
-            mkdir -p "$(dirname "${dir_path}${href}")"
-            if curl -s -f "${CURL_AUTH_ARRAY[@]}" -o "${dir_path}${href}" "${base_url}/${path_prefix}${href}"; then
-                echo "Downloaded: ${path_prefix}${href}"
+        norm="$href"
+        if [[ -n "$base_path_opt" ]]; then
+            if [[ "$href" == "$base_path_opt"/* ]]; then
+                norm="${href#$base_path_opt/}"
+            elif [[ "$href" == "$base_path_opt" ]]; then
+                continue
             fi
+        fi
+        if [[ "$norm" == */ ]]; then
+            list_remote_files "$base_url" "${path_prefix}${norm}" "$base_path_opt"
+        else
+            echo "${path_prefix}${norm}"
         fi
     done
 }
 
-# Download full remote directory (HTML index) into dest_dir. base_url has no trailing slash.
+# Download full remote directory: list all files, then download in parallel. Log to TARBALL_GENERATION_LOG, progress on stdout.
 download_from_url() {
     local base_url="$1"
     local dest_dir="$2"
+    local list_file total count rel_path log_path
     mkdir -p "$dest_dir"
     build_curl_auth
-    download_directory_from_url "$base_url" "" "$dest_dir"
+    local base_path
+    base_path=$(get_base_path_from_url "$base_url")
+    log_path="$(pwd)/${TARBALL_GENERATION_LOG}"
+    echo "=== Download started at $(date) from $base_url ===" >> "$log_path"
+    list_file=$(mktemp 2>/dev/null || mktemp -t oom_list)
+    trap 'rm -f "$list_file"' RETURN
+    echo "Listing remote files..."
+    list_remote_files "$base_url" "" "$base_path" > "$list_file"
+    total=$(wc -l < "$list_file" | tr -d ' ')
+    if [[ "$total" -eq 0 ]]; then
+        echo "No files to download."
+        echo "=== Download completed at $(date) ===" >> "$log_path"
+        return 0
+    fi
+    echo "Downloading $total files (parallelism: $DOWNLOAD_PARALLEL_JOBS)..."
+    count=0
+    while IFS= read -r rel_path; do
+        [[ -z "$rel_path" ]] && continue
+        while [[ $(jobs -r 2>/dev/null | wc -l) -ge $DOWNLOAD_PARALLEL_JOBS ]]; do
+            sleep 0.2
+        done
+        (
+            mkdir -p "$(dirname "${dest_dir}/${rel_path}")"
+            if curl -s -f "${CURL_AUTH_ARRAY[@]}" -o "${dest_dir}/${rel_path}" "${base_url}/${rel_path}"; then
+                echo "Downloaded: $rel_path" >> "$log_path"
+            fi
+        ) &
+        ((count++)) || true
+        if [[ $((count % 50)) -eq 0 ]] && [[ "$count" -gt 0 ]]; then
+            printf "\r  Progress: %d/%d files" "$count" "$total"
+        fi
+    done < "$list_file"
+    wait
+    printf "\r  Progress: %d/%d files (done)\n" "$total" "$total"
+    echo "=== Download completed at $(date) ===" >> "$log_path"
 }
 
 # Upload all files under local_dir/tarballs/ to base_url/tarballs/ (PUT). base_url has no trailing slash.
+# Logs each upload to TARBALL_GENERATION_LOG in current directory; stdout stays minimal.
 upload_tarballs_to_url() {
     local base_url="$1"
     local local_dir="$2"
     local tarball_dir="${local_dir}/tarballs"
     local upload_base="${base_url}/tarballs"
+    local log_path
+    log_path="$(pwd)/${TARBALL_GENERATION_LOG}"
     build_curl_auth
     if [[ ! -d "$tarball_dir" ]]; then
-        echo "No tarballs to upload." >&2
+        echo "No tarballs to upload."
         return 0
     fi
+    local count=0
+    echo "=== Upload started at $(date) to ${upload_base}/ ===" >> "$log_path"
     for f in "$tarball_dir"/*.tgz "$tarball_dir"/*.tar.gz; do
         [[ -f "$f" ]] || continue
         name=$(basename "$f")
         if curl -s -f "${CURL_AUTH_ARRAY[@]}" -T "$f" "${upload_base}/${name}"; then
-            echo "Uploaded: ${upload_base}/${name}"
+            echo "Uploaded: ${upload_base}/${name}" >> "$log_path"
+            ((count++)) || true
         else
+            echo "Warning: upload failed: ${upload_base}/${name}" >> "$log_path"
             echo "Warning: upload failed: ${upload_base}/${name}" >&2
         fi
     done
+    echo "=== Upload completed at $(date) ===" >> "$log_path"
+    echo "Uploaded $count tarball(s)."
 }
 
 print_help() {
@@ -175,8 +241,9 @@ Options:
   -d, --output-dir DIR      Directory containing date-wise oom_results_*.csv files (default: output).
                             If DIR starts with http:// or https://, treats it as a URL: downloads the
                             directory (HTML index listing) into a temp dir, runs the generator, then
-                            uploads new tarballs to <URL>/tarballs/. Auth: REMOTE_USER + REMOTE_TOKEN
-                            (or JENKINS_USER + JENKINS_TOKEN), or .netrc.
+                            uploads new tarballs to <URL>/tarballs/. Auth: REMOTE_TOKEN only (Cookie),
+                            or REMOTE_USER + REMOTE_TOKEN, or JENKINS_USER + JENKINS_TOKEN, or .netrc.
+                            Download/upload details are written to tarball_generation.log in the current directory.
   -c, --codeowners-dir DIR  Path to konflux-release-data (contains CODEOWNERS, staging/CODEOWNERS).
                             If not set, script clones the repo to a temp dir, uses it, then deletes it.
                             Report always includes namespace owners (name + email via glab) when available.
@@ -199,7 +266,7 @@ Examples:
   $0 --pod-name audit-exporter-2fzlc -d output
   $0 -p oom-stress-retry -c /path/to/konflux-release-data   # include namespace owners (name + email via glab)
   $0 -p prefetch-dependencies -d output -c /path/to/konflux-release-data   # all options combined
-  REMOTE_USER=user REMOTE_TOKEN=token $0 -p my-pod -d https://jenkins.example.com/job/oom/ws/artifacts   # URL: download, generate, upload tarballs
+  REMOTE_TOKEN='...' $0 -p my-pod -d https://jenkins.example.com/...   # URL: download, generate, upload (Cookie auth; or use REMOTE_USER+REMOTE_TOKEN)
 
 EOF
 }
@@ -244,6 +311,7 @@ if [[ "$OUTPUT_DIR" == http://* || "$OUTPUT_DIR" == https://* ]]; then
     echo "Downloading from $REMOTE_URL into $TMP_DOWNLOAD ..."
     download_from_url "$REMOTE_URL" "$TMP_DOWNLOAD"
     OUTPUT_DIR="$TMP_DOWNLOAD"
+    echo "Generating Report ...."
 else
     if [[ ! -d "$OUTPUT_DIR" ]]; then
         echo "ERROR: Output directory not found: $OUTPUT_DIR" >&2
@@ -288,6 +356,15 @@ for csv in "${DATEWISE_CSVS[@]}"; do
         desc=$(echo "$line" | awk -F',' '{print $9}')
         log=$(echo "$line" | awk -F',' '{print $10}')
         [[ -z "$type" || -z "$desc" || -z "$log" ]] && continue
+        # In remote mode, CSV paths point to Jenkins server; rewrite to local downloaded paths
+        if [[ -n "$REMOTE_URL" ]]; then
+            if [[ "$desc" == *"logs_and_description_files/"* ]]; then
+                desc="${OUTPUT_DIR}/logs_and_description_files/${desc#*logs_and_description_files/}"
+            fi
+            if [[ "$log" == *"logs_and_description_files/"* ]]; then
+                log="${OUTPUT_DIR}/logs_and_description_files/${log#*logs_and_description_files/}"
+            fi
+        fi
         # Normalize type
         case "$(echo "$type" | tr '[:upper:]' '[:lower:]')" in
             oomkilled) type="OOMKilled" ;;
@@ -385,6 +462,11 @@ mkdir -p "$TARBALL_DIR"
 TMP_BASE=$(mktemp -d)
 trap 'rm -rf "$CODEOWNERS_TEMP_DIR" "$TMP_BASE" "${TMP_DOWNLOAD:-}"' EXIT
 
+# When in URL mode, append tarball creation details to log so stdout stays clean
+TARBALL_LOG_PATH=""
+[[ -n "$REMOTE_URL" ]] && TARBALL_LOG_PATH="$(pwd)/${TARBALL_GENERATION_LOG}"
+tarball_created_count=0
+
 for key in "${!FILES_BY_KEY[@]}"; do
     type="${key%%|*}"
     date_key="${key#*|}"
@@ -411,20 +493,21 @@ for key in "${!FILES_BY_KEY[@]}"; do
         if [[ -f "$desc" ]]; then
             cp "$desc" "$tmpdir/"
         else
-            echo "Warning: description file not found (skipped): $desc" >&2
+            if [[ -n "$TARBALL_LOG_PATH" ]]; then echo "Warning: description file not found (skipped): $desc" >> "$TARBALL_LOG_PATH"; else echo "Warning: description file not found (skipped): $desc" >&2; fi
         fi
         if [[ -f "$log" ]]; then
             cp "$log" "$tmpdir/"
         else
-            echo "Warning: log file not found (skipped): $log" >&2
+            if [[ -n "$TARBALL_LOG_PATH" ]]; then echo "Warning: log file not found (skipped): $log" >> "$TARBALL_LOG_PATH"; else echo "Warning: log file not found (skipped): $log" >&2; fi
         fi
     done
     # Only create tarball if at least one file was copied (avoid empty tarballs)
     if [[ -n "$(find "$tmpdir" -maxdepth 1 -type f 2>/dev/null)" ]]; then
         tar -czf "$tarball_path" -C "$tmpdir" .
-        echo "Created: $tarball_path"
+        if [[ -n "$TARBALL_LOG_PATH" ]]; then echo "Created: $tarball_path" >> "$TARBALL_LOG_PATH"; else echo "Created: $tarball_path"; fi
+        ((tarball_created_count++)) || true
     else
-        echo "Skipped (no files found): $tarball_path" >&2
+        if [[ -n "$TARBALL_LOG_PATH" ]]; then echo "Skipped (no files found): $tarball_path" >> "$TARBALL_LOG_PATH"; else echo "Skipped (no files found): $tarball_path" >&2; fi
     fi
 done
 
@@ -432,4 +515,5 @@ echo "Done. Tarballs written to $OUTPUT_DIR/tarballs/"
 if [[ -n "$REMOTE_URL" ]]; then
     echo "Uploading tarballs to $REMOTE_URL/tarballs/ ..."
     upload_tarballs_to_url "$REMOTE_URL" "$OUTPUT_DIR"
+    echo "Log written to $(pwd)/${TARBALL_GENERATION_LOG}"
 fi


### PR DESCRIPTION
## Add per-pod tarballs after run; fix Jenkins remote flow; doc updates
### Why
- **Single flow after a run:** We want both the per-pod report and date-wise tarballs for every reported pod without manually running the bundle generator per pod.
- **Jenkins / remote usage:** The tool is run in CI (e.g. every 24h) and artifacts live on a Jenkins workspace URL. We need the full remote path to work: point the bundle generator at that URL so it **downloads** the workspace (CSVs + logs/descriptions), **builds** tarballs from that data, and **uploads** new tarballs back—so Jenkins is the source of truth and tarballs are produced where the job runs.
- **Clarity for later:** Document current behavior (including remote mode and 405) and the future idea of using Splunk when cluster logs are gone.
---
### What
- **`oc_get_ooms.py`:** After the per-pod summary, generates date-wise tarballs for each reported pod under `output/tarballs/`, using a match string so the bundle generator finds the right CSV rows. New **`--no-tarballs`** flag to skip. README and help updated.
- **`oom_logs_and_desc_bundle_generator` (Jenkins/URL mode):**
  - **Auth:** **REMOTE_TOKEN-only** (Cookie) so Jenkins session auth works without `REMOTE_USER`.
  - **Download:** List remote dir (with base-path normalization), then **parallel download** (default 20 workers, `DOWNLOAD_PARALLEL_JOBS`).
  - **Paths:** In URL mode, **rewrite CSV artifact paths** to the local download dir so tarballs are built from the downloaded files.
  - **Logging:** All download/upload detail in **`tarball_generation.log`**; stdout shows a **single-line progress** (e.g. `Progress: 480/480 files (done)`) and "Generating Report ...." right after download.
  - **Upload:** New tarballs uploaded to `<URL>/tarballs/` via HTTP PUT. **405** = server does not allow PUT; download, report, and tarball creation still succeed. Documented in README.
- **README:** Automatic per-pod tarballs and `--no-tarballs`; per-pod vs bundle generator and match strings; **"Remote (URL) mode"** summary stressing **Jenkins usage** (auth, log, progress, parallelism, path handling, 405); "Possible future: Logs from Splunk when cluster logs are gone" under Future Enhancements.
---
### How
- **Per-pod tarballs:** Group current-run pods by display base name; for each group compute a **match string** (longest common prefix of actual pod names) and run `oom_logs_and_desc_bundle_generator -p <match_str> -d <output>`. **`--no-tarballs`** skips these invocations.
- **Jenkins/URL mode in the bundle generator:**
  - **Auth:** If only `REMOTE_TOKEN` is set, use it as a Cookie header.
  - **Download:** Resolve base path from URL; strip that base from hrefs when parsing directory listings. List all file URLs, then download in parallel (up to `DOWNLOAD_PARALLEL_JOBS`). Append "Downloaded: …" and warnings to `tarball_generation.log`; on stdout show only "Listing remote files…", "Downloading N files (parallelism: 20)…", and "Progress: M/N files (done)".
  - **Paths:** When building tarballs from CSVs in URL mode, rewrite paths containing `logs_and_description_files/` to `<download_dir>/logs_and_description_files/<rest>`.
  - **Upload:** PUT each tarball to `<base_url>/tarballs/<filename>`; log to `tarball_generation.log`; on stdout print "Uploaded K tarball(s)." and once "Log written to …/tarball_generation.log".
  - **UX:** Print "Generating Report ...." as soon as download finishes.
- **Docs:** README sections for per-pod tarballs, `--no-tarballs`, match-string behavior, and a **"Remote (URL) mode"** subsection that stresses **Jenkins usage**: token-only auth, log file, single-line progress, parallel downloads, path normalization and CSV rewriting, and 405 meaning server does not allow PUT.
---
**Jenkins usage in short:** Run the bundle generator with `-d <Jenkins workspace URL>`. Set `REMOTE_TOKEN` (e.g. Jenkins cookie). The script downloads the workspace (parallel), rewrites CSV paths to the download dir, builds tarballs, and uploads them to `<URL>/tarballs/`. All detail is in `tarball_generation.log`; stdout stays minimal. If the server does not allow PUT, uploads fail with 405; the rest of the run still completes.
---
Signed-off-by: "Subrata Modak" <smodak@redhat.com>  
Assisted-by: Cursor-AI@cursor.com