### PR TITLE
Fix bundle generator on Jenkins: shebang and invocation

### DIFF
--- a/tools/oomkill-and-crashloopbackoff-detector/oc_get_ooms.py
+++ b/tools/oomkill-and-crashloopbackoff-detector/oc_get_ooms.py
@@ -3030,6 +3030,7 @@ def main() -> None:
                 if not match_str:
                     continue
                 cmd = [
+                    "bash",
                     str(bundle_gen),
                     "-p", match_str,
                     "-d", str(output_dir),

--- a/tools/oomkill-and-crashloopbackoff-detector/oom_logs_and_desc_bundle_generator
+++ b/tools/oomkill-and-crashloopbackoff-detector/oom_logs_and_desc_bundle_generator
@@ -1,4 +1,4 @@
-#!/opt/homebrew/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
**Fix bundle generator on Jenkins: shebang and invocation**

**Why**

After merging the per-pod tarball and Jenkins remote flow (PR #50), the detector started failing on Jenkins when generating tarballs with:

FileNotFoundError: [Errno 2] No such file or directory: '.../oom_logs_and_desc_bundle_generator'

The script was present; the failure came from the shebang pointing to a macOS-only path (#!/opt/homebrew/bin/bash), which does not exist on Jenkins Linux nodes. The kernel then reports “no such file or directory” for the script when it cannot find the interpreter.

**What**

oom_logs_and_desc_bundle_generator: Shebang changed from #!/opt/homebrew/bin/bash to #!/usr/bin/env bash so it runs on both macOS and Linux.
oc_get_ooms.py: The bundle generator is now invoked as bash <path_to_script> ... instead of executing the script path directly. The shebang is not used, so the run no longer depends on the script’s execute bit or interpreter path and works on Jenkins.
How

Shebang: one-line change to #!/usr/bin/env bash.
Invocation: prepend "bash" to the subprocess.run(cmd, ...) argument list so the first element is the interpreter and the script path is the first argument. No new options; behavior unchanged for users.
Jenkins: With this fix, the “Generating tarballs for N pod(s) ...” step runs successfully on Jenkins; no extra env or job config required.

The Jenkins error (https://jenkins-csb-perf-master.dno.corp.redhat.com/view/Konflux/job/StoneSoupOOMDetector/39/console) was:
```
==============================================
Report for pod: wheel-check-*-install-and-import
==============================================
OOMKilled: 0 instances (no occurrences in date-wise CSVs)
CrashLoopBackOff: 1 instance(s) on 12-Mar-2026, Namespace: calunga-tenant (cluster: kflux-prd-rh03) (no CODEOWNERS repo available)
==============================================

[1;34mGenerating tarballs for 90 pod(s) ...[0m
Traceback (most recent call last):
  File "/home/jenkins/workspace/StoneSoupOOMDetector/perfscale/tools/oomkill-and-crashloopbackoff-detector/./oc_get_ooms.py", line 3047, in <module>
    main()
    ~~~~^^
  File "/home/jenkins/workspace/StoneSoupOOMDetector/perfscale/tools/oomkill-and-crashloopbackoff-detector/./oc_get_ooms.py", line 3039, in main
    rc = subprocess.run(cmd, cwd=str(script_dir))
  File "/usr/lib64/python3.13/subprocess.py", line 554, in run
    with Popen(*popenargs, **kwargs) as process:
         ~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.13/subprocess.py", line 1039, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                        pass_fds, cwd, env,
                        ^^^^^^^^^^^^^^^^^^^
    ...<5 lines>...
                        gid, gids, uid, umask,
                        ^^^^^^^^^^^^^^^^^^^^^^
                        start_new_session, process_group)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.13/subprocess.py", line 1972, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: '/home/jenkins/workspace/StoneSoupOOMDetector/perfscale/tools/oomkill-and-crashloopbackoff-detector/oom_logs_and_desc_bundle_generator'
[Pipeline] }
[Pipeline] // dir
[Pipeline] }
[Pipeline] // stage
[Pipeline] stage
[Pipeline] { (Declarative: Post Actions)
[Pipeline] sh
+ rm -f /tmp/kubeconfig-Konflux-oom-crash-detector
[Pipeline] }
[Pipeline] // stage
[Pipeline] }
[Pipeline] // timeout
[Pipeline] }
Lock released on resource [Resource: RHTAP-oom-crash-detector]
[Pipeline] // lock
[Pipeline] }
[Pipeline] // withEnv
[Pipeline] }
[Pipeline] // container
[Pipeline] }
[Pipeline] // withEnv
[Pipeline] }
[Pipeline] // node
[Pipeline] }
[Pipeline] // podTemplate
[Pipeline] End of Pipeline
ERROR: script returned exit code 1
Finished: FAILURE
```