### PR TITLE
refactor(grafonnet): rename task-run Horreum label file and keys

### DIFF
--- a/grafonnet-workdir/src/horreum_task_run_labels.json
+++ b/grafonnet-workdir/src/horreum_task_run_labels.json
@@ -1,5 +1,5 @@
 {
-  "taskStepMemoryLabels": [
+  "taskRunMemoryLabels": [
     "__measurements_taskruns__build_apply_tags__memory_mean",
     "__measurements_taskruns__build_build_image_index__memory_mean",
     "__measurements_taskruns__build_buildah_oci_ta__memory_mean",
@@ -31,7 +31,7 @@
     "__measurements_taskruns__managed_verify_conforma_konflux_ta__memory_mean",
     "__measurements_taskruns__test_test_output__memory_mean"
   ],
-  "taskStepCpuLabels": [
+  "taskRunCpuLabels": [
     "__measurements_taskruns__build_apply_tags__cpu_mean",
     "__measurements_taskruns__build_build_image_index__cpu_mean",
     "__measurements_taskruns__build_buildah_oci_ta__cpu_mean",

--- a/grafonnet-workdir/src/probes.libsonnet
+++ b/grafonnet-workdir/src/probes.libsonnet
@@ -2,8 +2,8 @@ local grafonnet = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main
 // Horreum label names for measurements.taskruns only (memory/cpu mean) — Grafana panels avoid
 // __measurements_steps__* noise (KONFLUX-12065); step data remains in Horreum/PostgreSQL.
 // Regenerate from e2e-tests ci-scripts/config/horreum-schema.json when that schema changes:
-//   jq -n --slurpfile s PATH/horreum-schema.json '{ "taskStepMemoryLabels": ([$s[0].labels[] | .name | select(test("^__measurements_taskruns__") and test("__memory_mean$"))] | sort), "taskStepCpuLabels": ([$s[0].labels[] | .name | select(test("^__measurements_taskruns__") and test("__cpu_mean$"))] | sort) }' > grafonnet-workdir/src/horreum_task_step_labels.json
-local horreumTaskStepLabels = import 'horreum_task_step_labels.json';
+//   jq -n --slurpfile s PATH/horreum-schema.json '{ "taskRunMemoryLabels": ([$s[0].labels[] | .name | select(test("^__measurements_taskruns__") and test("__memory_mean$"))] | sort), "taskRunCpuLabels": ([$s[0].labels[] | .name | select(test("^__measurements_taskruns__") and test("__cpu_mean$"))] | sort) }' > grafonnet-workdir/src/horreum_task_run_labels.json
+local horreumTaskRunLabels = import 'horreum_task_run_labels.json';
 
 // Just some shortcuts
 local dashboard = grafonnet.dashboard;
@@ -231,8 +231,8 @@ local pieChart = grafonnet.panel.pieChart;
 
 
   // Task run memory and CPU — Horreum labels for measurements.taskruns only (KONFLUX-12065)
-  taskStepMemoryLabels: horreumTaskStepLabels.taskStepMemoryLabels,
-  taskStepCpuLabels: horreumTaskStepLabels.taskStepCpuLabels,
+  taskRunMemoryLabels: horreumTaskRunLabels.taskRunMemoryLabels,
+  taskRunCpuLabels: horreumTaskRunLabels.taskRunCpuLabels,
 
   completeDashboard(
     dashboardName='',
@@ -302,9 +302,9 @@ local pieChart = grafonnet.panel.pieChart;
       self.durationsPanel(testId, [i + 'passed_duration_samples' for i in platformTaskRunStubs], 'none', 'Count of platform task runs', extraFilters=extraFilters),
       // Task run memory and CPU — taskruns only per KONFLUX-12065 (steps remain in Horreum, not graphed here)
       row.new('Task run memory (mean)'),
-      self.durationsPanel(testId, self.taskStepMemoryLabels, 'bytes', 'Task run memory', extraFilters=extraFilters),
+      self.durationsPanel(testId, self.taskRunMemoryLabels, 'bytes', 'Task run memory', extraFilters=extraFilters),
       row.new('Task run CPU (mean)'),
-      self.durationsPanel(testId, self.taskStepCpuLabels, 'short', 'Task run CPU', extraFilters=extraFilters),
+      self.durationsPanel(testId, self.taskRunCpuLabels, 'short', 'Task run CPU', extraFilters=extraFilters),
     ]),
 
 }


### PR DESCRIPTION
## Why

Loadtest Grafana dashboards were emitting many time series for both **task runs** (`__measurements_taskruns__*`) and **steps** (`__measurements_steps__*`). Step-level series add noise in Grafana while the same data remains available in Horreum/PostgreSQL for deeper analysis.

This change limits the **Grafana** panels to **task-run** memory and CPU means only, matching the goal of clearer dashboards without dropping data from Horreum.

## What

- **`grafonnet-workdir/src/probes.libsonnet`** — Comments and panel copy updated for task-run–only queries; jq note documents regenerating labels from e2e-tests `horreum-schema.json`.
- **`grafonnet-workdir/src/horreum_task_run_labels.json`** — Label lists restricted to `__measurements_taskruns__*` memory/cpu mean fields (no `__measurements_steps__*` entries). Keys: `taskRunMemoryLabels`, `taskRunCpuLabels`.
- **`grafonnet-workdir/generated/`** — Regenerated `loadtest-probe.json`, `loadtest-probe-rpm.json`, `loadtest-probe-multiarch.json` via `grafonnet-workdir/build.sh`.

## How to verify

- Import the generated JSON into Grafana and confirm Task run memory/CPU panels query only `__measurements_taskruns__*` labels and that panels behave as expected for your probe runs.

## Jira

- **KONFLUX-12065**