### PR TITLE
feat(analyze_resource_limits): coverage reporting, disk I/O metrics, violators sub-tables

### DIFF
--- a/tools/tasks-and-steps-resource-analyzer/README.md
+++ b/tools/tasks-and-steps-resource-analyzer/README.md
@@ -1,734 +1,274 @@
-Scripts for extracting Memory and CPU Usage Metrics
-====================================================
-
-This directory contains scripts for extracting memory and CPU usage metrics (Max, P95, P90, Median) for each `task` and `step` executed inside Konflux clusters. These scripts were created while addressing: https://issues.redhat.com/browse/KONFLUX-6712.
-
-The workflow supports:
-- **Multi-cluster execution** - Iterates over all configured clusters
-- **Memory and CPU metrics** - Max, P95, P90, and Median per task/step
-- **Optimized batching** - Handles unlimited pods with intelligent batching; 1–30+ days with adaptive query resolution
-- **Task-scoped queries** - Metrics only from pods belonging to the specified task
-- **CSV / JSON / colorized text** - Multiple output formats; per-pod attribution (max memory / max CPU pod)
-- **Metadata** - Namespace, component, application where available
-- **Parallel clusters** - `--pll-clusters N` for concurrent cluster processing
-- **Cluster connectivity validation** - Pre-flight check before data collection
-
-Architecture Overview (ASCII Diagram)
-===================================
-```text
-                                     ┌───────────────────────────────────────────┐
-                                     │ wrapper_for_promql_for_all_clusters.sh    │
-                                     │───────────────────────────────────────────│
-                                     │ • Entry point for the entire workflow     │
-                                     │ • Iterates over all Konflux clusters      │
-                                     │ • Switches kube context per cluster       │
-                                     └──────────────────────────────┬────────────┘
-                                                                    │
-                                                                    ▼
-                   ┌────────────────────────────────────────────────────────────────────┐
-                   │     kube context: (cluster-1 / cluster-2 / cluster-N)              │
-                   └──────────────────────────────────────┬─────────────────────────────┘
-                                                          │
-                                                          ▼
-          ┌──────────────────────────────────────────────────────────────────────────┐
-          │                 wrapper_for_promql.sh (per cluster driver)               │
-          │──────────────────────────────────────────────────────────────────────────│
-          │ • Reads task list (task_name + step_name)                                │
-          │ • For each <task, step> pair:                                            │
-          │       - Calls Python script to list pods (filtered by task label)        │
-          │       - Processes pods in batches (50 pods per batch) to avoid limits    │
-          │       - Queries memory and CPU metrics for each batch                    │
-          │       - Aggregates results across all batches                            │
-          │ • Passes through OUTPUT_MODE (human, json, csv)                          │
-          └──────────────────────────────┬───────────────────────────────────────────┘
-                                         │
-                                         ▼
-                 ┌────────────────────────────────────────────────────────────┐
-                 │   list_pods_for_a_particular_task.py                       │
-                 │────────────────────────────────────────────────────────────│
-                 │ • Accepts task, step, fuzzy namespace ("*-tenant")         │
-                 │ • Discovers matching namespaces automatically              │
-                 │ • Locates all pods belonging to that task/step             │
-                 │ • Returns pod list to wrapper_for_promql.sh                │
-                 └──────────────────────────────┬─────────────────────────────┘
-                                                │
-                                                ▼
-             ┌─────────────────────────────────────────────────────────────────────┐
-             │ query_prometheus_range.py (optimized)                               │
-             │─────────────────────────────────────────────────────────────────────│
-             │ • Accepts PromQL query, start time, end time                        │
-             │ • Uses adaptive step sizing based on time range:                    │
-             │        - ≤1 day: 30s step                                           │
-             │        - ≤7 days: 5m step                                           │
-             │        - ≤30 days: 15m step                                         │
-             │        - >30 days: 1h step                                          │
-             │ • Sends HTTP requests to Prometheus API                             │
-             │ • Executes queries for:                                             │
-             │        - container_memory_working_set_bytes (actual memory usage)   │
-             │        - container_cpu_usage_seconds_total (with rate calculation)  │
-             │        - container_cpu_usage_seconds_total (with rate calculation)  │
-             │ • Returns time series data for aggregation                          │
-             └──────────────────────────────┬──────────────────────────────────────┘
-                                            │
-                                            ▼
-                     ┌──────────────────────────────────────────────────────────┐
-                     │             Aggregators in wrapper_for_promql.sh         │
-                     │──────────────────────────────────────────────────────────│
-                     │ • Processes pods in batches (50 per batch)               │
-                     │ • For each batch:                                        │
-                     │        - Queries memory max, p95, p90, median            │
-                     │          (uses container_memory_working_set_bytes for    │
-                     │           actual usage, not limits)                      │
-                     │        - Queries CPU max, p95, p90, median               │
-                     │        - Validates returned pods belong to task          │
-                     │ • Aggregates across all batches:                         │
-                     │        - Finds global max memory pod and value           │
-                     │        - Finds global max CPU pod and value              │
-                     │        - Calculates accurate percentiles across all pods │
-                     │ • Creates consolidated records                           │
-                     │ • Delegates final formatting to output backends          │
-                     └──────────────────────────────┬───────────────────────────┘
-                                                    │
-                                                    ▼
-       ┌────────────────────────────────────────────────────────────────────────────┐
-       │             Output Formatter (human / color / CSV / JSON)                  │
-       │────────────────────────────────────────────────────────────────────────────│
-       │ • Human mode:                                                              │
-       │       - ANSI-colored tables                                                │
-       │       - MAX above threshold marked in red                                  │
-       │ • CSV mode:                                                                │
-       │       - Comma-separated values for spreadsheets                            │
-       │ • JSON mode:                                                               │
-       │       - Machine-readable structured output                                 │
-       │ • Output returned to wrapper_for_promql_for_all_clusters.sh                │
-       └────────────────────────────────────────────────────────────────────────────┘
-```
-
-
-How to Run
+Tasks and Steps Resource Analyzer
 ===================================
 
-Run for last N days:
+Analyzes **actual** memory, CPU, and disk I/O usage of every step in a Konflux Tekton Task
+across all clusters and recommends right-sized Kubernetes `computeResources`.
+Data comes from Prometheus (`container_memory_working_set_bytes`, `container_cpu_usage_seconds_total`,
+`container_fs_reads/writes_bytes_total`) over a configurable window (default: last 7 days).
 
-    ./wrapper_for_promql_for_all_clusters.sh <num_of_days> [--csv] [--table] [--raw] [--debug]
+Supports MAX, P95, P90, and Median as recommendation bases, with a configurable safety margin.
 
-**Examples:**
+---
+
+## Quick Start
+
+> ⏱ **Runtime**: 30 seconds to several hours depending on cluster data volume.
+> Use `--pll-clusters 4` (see [Speed Tips](#speed-tips)) for the fastest run.
+
+**Step 1 — Clone and set up a Python virtual environment**
 
 ```bash
-# Default: CSV output (pipeable, suitable for scripts)
-./wrapper_for_promql_for_all_clusters.sh 7 --csv
-
-# Table format: Human-readable table (automatically used when outputting to terminal)
-./wrapper_for_promql_for_all_clusters.sh 7 --table
-
-# Raw CSV: Explicitly request raw CSV output (for piping to other tools)
-./wrapper_for_promql_for_all_clusters.sh 7 --raw
-
-# Debug mode: Shows detailed query information
-./wrapper_for_promql_for_all_clusters.sh 7 --csv --debug
-
-# Pipe to analysis tool (uses raw CSV automatically)
-./wrapper_for_promql_for_all_clusters.sh 7 --csv | ./analyze_resource_limits.py
-```
-
-**Output Format Behavior:**
-- **Default (no flags)**: If output is to a terminal, shows table format. If piped, outputs raw CSV.
-- **`--table`**: Explicitly request table format (useful for scripts)
-- **`--raw`**: Explicitly request raw CSV (useful when you want CSV even in terminal)
-- **`--csv`**: Legacy flag, same as default behavior
-
-The PromQL range window and sampling delta adjust automatically based on the time range:
-- **1 day**: 30-second resolution for fine-grained analysis
-- **7 days**: 5-minute resolution (optimized for Prometheus limits)
-- **30 days**: 15-minute resolution
-- **30+ days**: 1-hour resolution
-
-**Performance Optimizations:**
-- **Intelligent Batching**: Pods are processed in batches of 50 to avoid URL length and query complexity limits
-- **Task-Scoped Queries**: All metrics are validated to ensure they only come from pods belonging to the specified task
-- **Adaptive Step Sizing**: Query resolution automatically adjusts to stay within Prometheus data point limits
-- **Efficient Aggregation**: Percentiles are calculated accurately across all pods, not per-batch
-
-Python Virtual Environment
-===================================
-
-It is recommended to create a venv:
-
-    python -m venv promql_for_mem_metrics; source promql_for_mem_metrics/bin/activate
-
-**Required Python packages:**
-```bash
+git clone git@github.com:redhat-appstudio/perfscale.git
+cd perfscale
+python -m venv venv && source venv/bin/activate
 pip install requests pyyaml
 ```
 
-CSV Output Format
-===================================
-The CSV output includes both memory and CPU metrics with separate pod attribution:
+**Step 2 — Log in to all Konflux clusters**
 
-```
-"cluster", "task", "step", "pod_max_mem", "namespace_max_mem", "component_max_mem", "application_max_mem", "mem_max_mb", "mem_p95_mb", "mem_p90_mb", "mem_median_mb", "pod_max_cpu", "namespace_max_cpu", "component_max_cpu", "application_max_cpu", "cpu_max", "cpu_p95", "cpu_p90", "cpu_median"
-```
+You need a valid `kubeconfig` for every cluster you want data from.
+The easiest way is to use the `oclogin-all` helper in this repo:
 
-**Column Descriptions:**
-- `pod_max_mem` - Pod name with the highest memory usage
-- `namespace_max_mem` - Namespace of the pod with max memory
-- `component_max_mem` - Component name for the max memory pod (if available)
-- `application_max_mem` - Application name for the max memory pod (if available)
-- `mem_max_mb` - Maximum memory usage in MB
-- `mem_p95_mb`, `mem_p90_mb`, `mem_median_mb` - Memory percentiles in MB
-- `pod_max_cpu` - Pod name with the highest CPU usage
-- `namespace_max_cpu` - Namespace of the pod with max CPU
-- `component_max_cpu` - Component name for the max CPU pod (if available)
-- `application_max_cpu` - Application name for the max CPU pod (if available)
-- `cpu_max`, `cpu_p95`, `cpu_p90`, `cpu_median` - CPU metrics in millicores (e.g., "3569m")
-
-CSV Output Example
-===================================
-(Step values may appear with or without `step-` prefix. Data rows illustrate the shape; full CSV has 19 columns as in the header.)
-```
-"cluster","task","step","pod_max_mem","namespace_max_mem","component_max_mem","application_max_mem","mem_max_mb","mem_p95_mb","mem_p90_mb","mem_median_mb","pod_max_cpu","namespace_max_cpu","component_max_cpu","application_max_cpu","cpu_max","cpu_p95","cpu_p90","cpu_median"
-"stone-prd-rh01","buildah","step-build","maestro-on-pull-request-wtpkk-build-container-pod","maestro-rhtap-tenant","N/A","N/A","8192","8191","8190","8183","operator-on-pull-request-45m69-build-container-pod","vp-operator-release-tenant","N/A","N/A","3569m","3569m","3569m","3569m"
-"kflux-prd-rh02","buildah","step-push","175","rhobs-observato8863c7ac646c45ff10fb9046c502710ae37ef8bf870e-pod","rhobs-mco-tenant","N/A","N/A","0","0","0"
-"kflux-prd-rh02","buildah","step-sbom-syft-generate","10","rhobs-observatoee6e952803459989d848471898dd7a5ad76331c37d9f-pod","rhobs-mco-tenant","N/A","N/A","0","0","0"
-"kflux-prd-rh02","buildah","step-prepare-sboms","10","crc-binary-on-pull-request-6kgk9-build-container-pod","crc-tenant","N/A","N/A","0","0","0"
-"kflux-prd-rh02","buildah","step-upload-sbom","10","rhobs-observatorium-api-main-on-push-jvj2w-build-container-pod","rhobs-mco-tenant","N/A","N/A","5","5","5"
-"kflux-prd-rh03","buildah","step-build","2218","rosa-log-router-processor-go-on-push-rhfrf-build-container-pod","rosa-log-router-tenant","N/A","N/A","0","0","0"
-"kflux-prd-rh03","buildah","step-push","291","rosa-log-router-api-on-push-7m4q6-build-container-pod","rosa-log-router-tenant","N/A","N/A","0","0","0"
-"kflux-prd-rh03","buildah","step-sbom-syft-generate","26","rosa-log-router-authorizer-on-push-9rjjt-build-container-pod","rosa-log-router-tenant","N/A","N/A","0","0","0"
-"kflux-prd-rh03","buildah","step-prepare-sboms","10","rosa-clusters-service-main-on-push-889lb-build-container-pod","ocm-tenant","N/A","N/A","0","0","0"
-"kflux-prd-rh03","buildah","step-upload-sbom","10","rosa-log-router8a62df9c0d552405a950b37393ec02899f7d63a55582-pod","rosa-log-router-tenant","N/A","N/A","0","0","0"
-"stone-prd-rh01","buildah","step-build","8192","maestro-on-pull-request-bd8gq-build-container-pod","maestro-rhtap-tenant","N/A","N/A","33","33","32"
-"stone-prd-rh01","buildah","step-push","4096","mintmaker-renovate-image-onfb4dbfe538bfbe5501da4d85e1a8841b-pod","konflux-mintmaker-tenant","N/A","N/A","5","5","5"
-"stone-prd-rh01","buildah","step-sbom-syft-generate","4096","mintmaker-renovate-image-on-push-6p2v2-build-container-pod","konflux-mintmaker-tenant","N/A","N/A","5","5","4"
-"stone-prd-rh01","buildah","step-prepare-sboms","147","git-partition-sb74fb1d75007f3983ea4fcfb634aedfed55841810a57-pod","app-sre-tenant","N/A","N/A","5","5","5"
-"stone-prd-rh01","buildah","step-upload-sbom","30","image-builder-frontend-on-p3a8a424d61bda08ebddf65ed7412c350-pod","insights-management-tenant","N/A","N/A","5","5","5"
-"stone-prod-p02","buildah","step-build","8192","kubectl-package-internal-on-push-rzvcb-build-container-pod","mos-lpsre-tenant","N/A","N/A","32","32","19"
-"stone-prod-p02","buildah","step-push","2029","ocmci-on-pull-request-zlcvq-build-container-pod","ocmci-tenant","N/A","N/A","0","0","0"
-"stone-prod-p02","buildah","step-sbom-syft-generate","1375","osd-fleet-manager-main-on-p96be62f96f3b274d6a8261f92ea05f12-pod","fleet-manager-tenant","N/A","N/A","0","0","0"
-"stone-prod-p02","buildah","step-prepare-sboms","12","ocm-ams-master-on-pull-request-hrmqm-build-container-pod","ocm-tenant","N/A","N/A","0","0","0"
-"stone-prod-p02","buildah","step-upload-sbom","29","web-rca-ui-main-on-pull-request-jblvn-build-container-pod","hcm-eng-prod-tenant","N/A","N/A","0","0","0"
-"stone-stg-rh01","buildah","step-build","0","","N/A","N/A","N/A","0","0","0"
-"stone-stg-rh01","buildah","step-push","0","","N/A","N/A","N/A","0","0","0"
-"stone-stg-rh01","buildah","step-sbom-syft-generate","0","","N/A","N/A","N/A","0","0","0"
-"stone-stg-rh01","buildah","step-prepare-sboms","0","","N/A","N/A","N/A","0","0","0"
-"stone-stg-rh01","buildah","step-upload-sbom","0","","N/A","N/A","N/A","0","0","0"
-```
-Resource Limit Analysis Tool
-===================================
-
-The `analyze_resource_limits.py` script analyzes resource consumption data and provides recommendations for Kubernetes resource limits with advanced features like caching, comparison tables, and patch file generation.
-
-**YAML steps vs. observability data**
-
-When you use `--file`, the confirmation prompt lists **every** step from the Task YAML. Tables and recommendations, however, include **only steps that had at least one usable Prometheus sample** for `container="step-<name>"` in the analysis window (`--days`). If a YAML step has no matching usage data, the tool prints a **WARNING** on stderr with those step names, and records them in the **`steps_without_observability_data`** field in the analyzed-data and comparison JSON (with a short notice in the generated HTML). Typical reasons: TaskRuns resolved to older bundles without that step, no pods in the window, or a remote StepAction whose runtime container name does not match `step-<metadata.name>`.
-
-Step names that **contain** the substring `step-` in the middle (for example `fips-operator-check-step-action`) are normalized by removing **only** the leading Tekton `step-` prefix, not every `step-` substring—so names are not corrupted when matching YAML to metrics.
-
-**Features:**
-
-**Major Features:**
-- **Parallel Cluster Processing**: Process multiple clusters concurrently with `--pll-clusters N` flag for faster data collection
-- **Dry-Run Mode**: Validate task/steps and check cluster connectivity without running data collection using `--dry-run` flag
-- **Unified Execution Modes**: Serial and parallel execution modes now have consistent progress indicators, summary output, and error reporting
-- **Task/Step Validation**: Automatically validates wrapper-defined steps against YAML file steps before proceeding with analysis
-
-**Core Features:**
-- **Automatic Data Collection**: Can extract task/step info from YAML and automatically run data collection
-- **Missing-step visibility**: If YAML declares steps with no observability data in the run, stderr WARNING plus `steps_without_observability_data` in saved JSON/HTML
-- **Caching System**: Recommendations are cached, allowing review before applying changes
-- **Comparison Tables**: Shows current vs proposed resource limits side-by-side
-- **HTML Output for Trend Analysis**: Automatically generates HTML files with timestamped filenames:
-  - **CSV Data HTML**: Sortable table of all collected resource usage data (`{task_name}_analyzed_data_{timestamp}.html`)
-  - **Comparison HTML**: Non-sortable table showing current vs proposed resource limits (`{task_name}_comparison_data_{timestamp}.html`)
-  - Files saved in `.analyze_cache/` directory with timestamps for trend analysis
-  - HTML files are browser-compatible with no external dependencies
-- **Configurable Base Metrics**: Choose calculation base (max, P95, P90, median) with configurable safety margin
-- **Patch File Generation**: For remote GitHub URLs, generates `.patch` files for manual review
-- **Smart Rounding**: 
-  - Memory: Rounds UP to increments of 64Mi (< 1Gi) or whole Gi (>= 1Gi), minimum 64Mi
-  - CPU: Rounds UP to increments of 50m, minimum 50m
-- **Update from Cache**: Apply cached recommendations without re-running analysis
-
-**User Experience Improvements:**
-- **Progress Indicators**: Real-time progress spinner during data collection for both serial and parallel execution modes
-- **Cluster Display Names**: Consolidated cluster name extraction shows short, user-friendly names (e.g., "stone-stg-rh01") instead of full context strings throughout the UI
-- **Data Collection Summary**: Comprehensive summary report showing total clusters processed, successful/failed counts, and detailed error information
-- **Cluster Connectivity Check**: Pre-flight validation of all clusters before proceeding with data collection, displayed in a clear connectivity report
-
-**Usage Examples:**
-
-## Basic Usage Patterns
-
-**1. Analyze from piped CSV input:**
 ```bash
-./wrapper_for_promql_for_all_clusters.sh 7 --csv | ./analyze_resource_limits.py
+# Install oclogin / oclogin-all into your PATH, then:
+oclogin-all
 ```
 
-**2. Analyze from local YAML file (auto-runs data collection):**
+> ⚠️ `oclogin-all` **deletes and recreates** kubeconfig entries for all 12 known Konflux clusters.
+> Use with caution if you have other kubeconfig entries you want to preserve.
+>
+> Alternatively, log in to clusters manually so they appear in your `~/.kube/config`.
+
+**Step 3 — Run the analyzer**
+
 ```bash
-./analyze_resource_limits.py --file /path/to/buildah.yaml
+cd tools/tasks-and-steps-resource-analyzer
+
+./analyze_resource_limits.py \
+  --file https://github.com/konflux-ci/build-definitions/blob/main/task/fbc-fips-check-oci-ta/0.1/fbc-fips-check-oci-ta.yaml \
+  --analyze-again --margin 5 --days 15 --pll-clusters 4
 ```
 
-**3. Analyze from GitHub URL (auto-runs data collection):**
+Replace the `--file` URL with the task YAML you want to analyze. You will be shown a confirmation
+prompt listing the task name and steps before any data is collected.
+
+**Step 4 — Open the HTML reports**
+
+All output files land in `.analyze_cache/`:
+
 ```bash
-./analyze_resource_limits.py --file https://github.com/konflux-ci/build-definitions/blob/main/task/buildah/0.7/buildah.yaml
+ls -l .analyze_cache/*fbc-fips-check-oci-ta*.html
 ```
 
-## Phase 1: Analysis (Default Behavior)
+Example output:
+```
+.analyze_cache/fbc-fips-check-oci-ta_analyzed_data_20260409.html
+.analyze_cache/fbc-fips-check-oci-ta_comparison_data_margin-5_20260409.html
+.analyze_cache/fbc-fips-check-oci-ta_analyzed_data_detailed_step_fips-operator-check-step-action_20260409.html
+.analyze_cache/fbc-fips-check-oci-ta_analyzed_data_detailed_step_get-unique-related-images_20260409.html
+...
+```
 
-**Important:** Phase 1 (analysis) generates recommendations for ALL base metrics (max, p95, p90, median) regardless of the `--base` flag. The `--base` flag is **ignored** in Phase 1.
+Open the **`_comparison_data_`** HTML in your browser — it shows all four base metrics (MAX, P95,
+P90, Median) side by side so you can pick the right one for your PR.
 
-**4. Basic analysis (generates all base metrics):**
+**Step 5 — Apply changes manually**
+
+The tool **never modifies YAML files automatically**. Use the comparison report to decide which
+base metric to use, then update your task YAML accordingly.
+
+---
+
+## Speed Tips
+
+| Goal | Recommended flags |
+|---|---|
+| Fastest run | `--pll-clusters 4` (4 clusters in parallel) |
+| Wider history | `--days 15` (15 days instead of default 7) |
+| Force fresh data | `--analyze-again` (ignores existing cache) |
+| Skip data collection | `--update` (reuse existing Phase 1 cache) |
+| Validate before running | `--dry-run` (connectivity check only) |
+
+**Recommended command for most analyses:**
+
 ```bash
-# Generates recommendations for max, p95, p90, and median
-# --base flag is ignored in Phase 1
-./analyze_resource_limits.py --file /path/to/buildah.yaml
+./analyze_resource_limits.py \
+  --file <github-or-local-yaml-url> \
+  --analyze-again --margin 5 --days 15 --pll-clusters 4
 ```
 
-## Margin Configuration
+**Serial vs parallel:**
+- Default (no `--pll-clusters`): clusters processed one at a time — safe but slow
+- `--pll-clusters 4`: 4 clusters processed concurrently — ~4× faster, recommended
+- More than 6 workers may hit Prometheus rate limits; 4 is a good default
 
-**5. Custom safety margin (default is 5%):**
+---
+
+## Two-Phase Workflow
+
+### Phase 1 — Analysis (collect data, generate reports)
+
 ```bash
-# Use default 5% margin
-./analyze_resource_limits.py --file /path/to/buildah.yaml
-
-# Add 10% safety margin
-./analyze_resource_limits.py --file /path/to/buildah.yaml --margin 10
-
-# Add 20% safety margin
-./analyze_resource_limits.py --file /path/to/buildah.yaml --margin 20
+./analyze_resource_limits.py --file <yaml> --margin 5 --days 15 --pll-clusters 4
 ```
 
-**Note:** Margin is applied to all base metrics (max, p95, p90, median) in Phase 1.
+- Collects per-pod metrics from all clusters in parallel
+- Computes MAX, P95, P90, Median for every step
+- Saves to `.analyze_cache/`:
+  - `{task}_analyzed_data_{date}.html/json` — aggregate table
+  - `{task}_comparison_data_margin-5_{date}.html/json` — **main report**: all four bases, proposed vs current, plus violators sub-tables
+  - `{task}_analyzed_data_detailed_step_{step}_{date}.html/json/csv` — one file per step, every pod execution
 
-## Time Range Configuration
+At the end, the tool prints the path to the comparison HTML and exits. **No YAML is modified.**
 
-**9. Custom data collection period (default is 7 days):**
+### Phase 2 — Update (view recommendations for a different margin, no re-collection)
+
 ```bash
-# Analyze last 1 day
-./analyze_resource_limits.py --file /path/to/buildah.yaml --days 1
-
-# Analyze last 10 days
-./analyze_resource_limits.py --file /path/to/buildah.yaml --days 10
-
-# Analyze last 30 days
-./analyze_resource_limits.py --file /path/to/buildah.yaml --days 30
-
-# Combine with other options
-./analyze_resource_limits.py --file /path/to/buildah.yaml --days 10 --base p95 --margin 5
+./analyze_resource_limits.py --update --file <yaml> --margin 10
 ```
 
-## Parallel Processing
+- Reuses Phase 1 cache, generates a new comparison file for the requested margin
+- Creates `{task}_comparison_data_margin-10_{date}.html/json` alongside the existing `margin-5` file
+- Useful for comparing conservative vs aggressive margins without re-running data collection
 
-**10. Parallel cluster processing (faster for multiple clusters):**
+---
+
+## Key Options
+
+| Flag | Default | Description |
+|---|---|---|
+| `--file FILE` | — | Local YAML path or GitHub URL (required for Phase 1) |
+| `--days N` | 7 | History window for data collection |
+| `--margin N` | 5 | Safety margin % added to the base metric |
+| `--pll-clusters N` | serial | Number of clusters to query in parallel |
+| `--analyze-again` / `--aa` | off | Force re-collection even if today's cache exists |
+| `--update` | off | Phase 2: regenerate comparison from cache, no re-collection |
+| `--dry-run` | off | Connectivity check only, no data collection |
+| `--debug` | off | Verbose output for troubleshooting |
+
+> **Note on `--base`:** This flag is accepted but **ignored** — Phase 1 always generates all four
+> bases (max, p95, p90, median) so you can choose in the HTML report without re-running.
+
+---
+
+## Understanding the HTML Reports
+
+### `_comparison_data_margin-N_` (the main decision report)
+
+Open this first. For each base metric (MAX / P95 / P90 / Median) it shows:
+
+- **Proposed Requests / Limits** vs current values from the YAML
+- **Violators sub-table** (collapsible ▾): which namespaces, applications, and components had
+  observed usage *above* that base threshold — organized by namespace → application → component,
+  with exact peak values and `+delta ⚠` annotations. This answers *"who would OOM if I pick P95?"*
+- **Heavy-tail warning** (amber banner): steps where Max/P95 ratio ≥ 3× — rare but heavy workloads
+  can exceed the P95 line significantly
+- **Cluster data coverage** (blue banner): how many days of actual data each cluster returned
+  vs what was requested — reveals when Prometheus doesn't have the full window
+- **Scrape interval notice**: reminder that Prometheus scrapes every 15–30 s; sub-scrape memory
+  spikes (e.g. brief image decompression) may not be captured
+
+### `_analyzed_data_detailed_step_{step}_` (per-pod drill-down)
+
+Sortable table of every pod execution observed. Includes:
+- Peak memory (MB) and CPU (cores) per pod
+- **Peak Disk Read / Write (MB/s)** — rows highlighted amber when I/O exceeds 50 MB/s
+- Namespace, application, component attribution
+- Current requests and limits from the YAML
+- Timestamp of the execution
+
+Sort by `Final Memory Usage` or `Peak Disk Read` to quickly spot outlier workloads.
+
+---
+
+## Choosing a Base Metric
+
+| Base | Coverage | When to use |
+|---|---|---|
+| **MAX** | 100% of observed runs | Critical tasks where any OOM is unacceptable |
+| **P95** | 95% of runs | Most production tasks — balances safety and cost |
+| **P90** | 90% of runs | Cost-optimized tasks where rare OOMs are tolerable |
+| **Median** | 50% of runs | Non-critical / dev workloads only |
+
+**Recommendation for Konflux production tasks:** Start with P95 + 5% margin. If the comparison
+report shows significant violators for P95 (especially large or well-known tenants), consider MAX.
+
+**Calculation:**
+```
+recommended = max_across_clusters(base_metric) × (1 + margin / 100)
+# rounded UP to next 64Mi increment (< 1Gi) or whole Gi (≥ 1Gi) for memory
+# rounded UP to next 50m for CPU, minimum 50m
+```
+
+---
+
+## Output Files Reference
+
+| Pattern | Phase | Content |
+|---|---|---|
+| `{task}_analyzed_data_{date}.html/json` | 1 | Aggregate table: per-cluster MAX/P95/P90/Median |
+| `{task}_comparison_data_margin-{N}_{date}.html/json` | 1 & 2 | All four bases, proposed vs current, violators |
+| `{task}_analyzed_data_detailed_step_{step}_{date}.html/json/csv` | 1 | Per-pod execution data with I/O |
+
+All files land in `.analyze_cache/`. Re-running on the same date adds a `_HHMMSS` suffix to avoid
+overwriting earlier runs.
+
+---
+
+## Architecture
+
+```
+analyze_resource_limits.py  (orchestrator)
+  │
+  ├── per-cluster worker (threaded, --pll-clusters N)
+  │     ├── list_pods_for_a_particular_task.py   → Prometheus kube_pod_labels query
+  │     └── query_prometheus_range.py            → per-pod memory / CPU / I/O range queries
+  │           adaptive step: 30s (≤1d) · 5m (≤7d) · 15m (≤30d) · 1h (>30d)
+  │
+  └── wrapper_for_promql_for_all_clusters.sh  (legacy aggregation path, batched per-cluster)
+        └── wrapper_for_promql.sh  (per-cluster: 50-pod batches, max/p95/p90/median)
+```
+
+The primary path for `--file` usage is the Python threaded worker (direct per-pod queries).
+The shell wrapper path is the legacy stdin/pipe path.
+
+---
+
+## Cluster Authentication
+
+Log in to all clusters before running. Using the `oclogin` / `oclogin-all` helpers in this repo
+is the fastest approach — they generate kubeconfig entries for all 12 Konflux clusters.
+
 ```bash
-# Process 3 clusters concurrently
-./analyze_resource_limits.py --file /path/to/buildah.yaml --pll-clusters 3
-
-# Process 5 clusters concurrently
-./analyze_resource_limits.py --file /path/to/buildah.yaml --pll-clusters 5
-
-# Combine with other options
-./analyze_resource_limits.py --file /path/to/buildah.yaml --pll-clusters 3 --days 10 --base p95 --margin 5
+# After installing helpers into PATH:
+oclogin-all      # logs into all 12 clusters at once
 ```
 
-## Phase 2: Update (View Recommendations)
+Alternatively, log into clusters individually using `oc login` and ensure all contexts are
+present in your `~/.kube/config`.
 
-**Important:** Phase 2 (`--update`) requires `--file` to specify which task to update. The `--base` flag is **ignored** in Phase 2 - all base metrics (max, p95, p90, median) are always shown. YAML files are **NOT updated automatically** - you must update them manually after reviewing recommendations.
+---
 
-**11. View recommendations for all base metrics:**
-```bash
-# View recommendations for all base metrics (max, p95, p90, median)
-# --base flag is ignored in Phase 2, margin must be specified
-./analyze_resource_limits.py --update --file /path/to/buildah.yaml --margin 5
+## Known Limitations
 
-# Same as above (--base is ignored)
-./analyze_resource_limits.py --update --file /path/to/buildah.yaml --base p95 --margin 5
-```
+- **Prometheus scrape interval (~15–30 s):** Sub-scrape memory spikes are not captured.
+  `max_over_time` takes the max of all scraped samples — if a spike resolved between two scrapes,
+  it is invisible. The comparison HTML includes a notice about this.
+- **Prometheus history gaps:** Some clusters may return fewer days than requested if their
+  Prometheus retention is shorter. The cluster coverage banner in the HTML reports this per cluster.
+- **Bimodal distributions:** A step that handles both lightweight and very heavy payloads (e.g.
+  RHOAI FBC bundles vs small operators) will show very different MAX vs P95 values. The heavy-tail
+  warning banner flags these cases.
 
-**12. Update with different margin (creates new comparison files for each margin):**
-```bash
-# Create comparison files for margin 5% (if they don't exist)
-./analyze_resource_limits.py --update --file /path/to/buildah.yaml --margin 5
+---
 
-# Create comparison files for margin 10% (separate file, coexists with margin 5% file)
-./analyze_resource_limits.py --update --file /path/to/buildah.yaml --margin 10
+## Contributing / Feedback
 
-# Create comparison files for margin 20% (separate file, coexists with other margin files)
-./analyze_resource_limits.py --update --file /path/to/buildah.yaml --margin 20
+The tool has been used across Konflux to right-size resources for tasks including `buildah`,
+`fbc-fips-check`, `prefetch-dependencies`, and many others. If you find a bug, notice data
+that looks off, or have ideas for improvement:
 
-# If comparison file already exists for a margin, it's reused (no new file created)
-./analyze_resource_limits.py --update --file /path/to/buildah.yaml --margin 5
-```
-
-**13. Two-phase workflow (recommended):**
-```bash
-# Phase 1: Generate all base metrics (margin: 5%, days: 7)
-./analyze_resource_limits.py --file /path/to/buildah.yaml --margin 5 --days 7
-
-# Phase 2: View recommendations for all base metrics with margin 5%
-./analyze_resource_limits.py --update --file /path/to/buildah.yaml --margin 5
-
-# Phase 2: View recommendations for all base metrics with margin 10% (creates new file)
-./analyze_resource_limits.py --update --file /path/to/buildah.yaml --margin 10
-
-# Phase 2: View recommendations for all base metrics with margin 20% (creates new file)
-./analyze_resource_limits.py --update --file /path/to/buildah.yaml --margin 20
-```
-
-**Note:** You can run Phase 2 multiple times with different `--margin` values. Each margin gets its own comparison file, allowing you to compare recommendations across different margins. The `--base` flag is ignored - all base metrics are always shown.
-
-## Debug and Validation
-
-**16. Enable debug output:**
-```bash
-# Show detailed processing information
-./analyze_resource_limits.py --file /path/to/buildah.yaml --debug
-
-# Debug with update
-./analyze_resource_limits.py --update --file /path/to/buildah.yaml --debug
-
-# Debug with all options
-./analyze_resource_limits.py --file /path/to/buildah.yaml --pll-clusters 3 --days 10 --base p95 --margin 5 --debug
-```
-
-**17. Dry-run: Validate task/steps and check cluster connectivity:**
-```bash
-# Check connectivity and validate configuration without running data collection
-./analyze_resource_limits.py --file /path/to/buildah.yaml --dry-run
-
-# Dry-run with debug for more details
-./analyze_resource_limits.py --file /path/to/buildah.yaml --dry-run --debug
-```
-
-## Complete Examples with All Options
-
-**18. Full-featured analysis:**
-```bash
-# Analyze with P95 base, 15% margin, 10 days data, 4 parallel workers, debug output
-./analyze_resource_limits.py --file /path/to/buildah.yaml --base p95 --margin 15 --days 10 --pll-clusters 4 --debug
-```
-
-**19. Full-featured update workflow:**
-```bash
-# Step 1: Analyze with custom parameters
-./analyze_resource_limits.py --file https://github.com/.../buildah.yaml --base p95 --margin 15 --days 10 --pll-clusters 4
-
-# Step 2: Update local file using cache
-./analyze_resource_limits.py --update --file /path/to/local/buildah.yaml --debug
-```
-
-**20. Piped input with analysis:**
-```bash
-# Collect data and analyze in one command
-./wrapper_for_promql_for_all_clusters.sh 7 --csv | ./analyze_resource_limits.py
-```
-
-**21. Multiple independent task analyses (task-based caching):**
-```bash
-# Analyze task1 - saves to task1.json cache
-./analyze_resource_limits.py --file /path/to/task1.yaml --margin 5 --days 10
-
-# Analyze task2 - saves to task2.json cache (independent, doesn't overwrite task1 cache)
-./analyze_resource_limits.py --file /path/to/task2.yaml --margin 10 --days 7
-
-# Update task1 using its cache
-./analyze_resource_limits.py --update --file /path/to/task1.yaml
-
-# Update task2 using its cache
-./analyze_resource_limits.py --update --file /path/to/task2.yaml
-```
-
-## Common Workflow Combinations
-
-**Conservative approach (production-ready):**
-```bash
-./analyze_resource_limits.py --file /path/to/buildah.yaml --base max --margin 20 --days 14
-```
-
-**Balanced approach (recommended):**
-```bash
-./analyze_resource_limits.py --file /path/to/buildah.yaml --base p95 --margin 10 --days 7
-```
-
-**Aggressive optimization (cost-saving):**
-```bash
-./analyze_resource_limits.py --file /path/to/buildah.yaml --base p90 --margin 5 --days 7
-```
-
-**Quick validation:**
-```bash
-./analyze_resource_limits.py --file /path/to/buildah.yaml --dry-run
-```
-
-**Command-line Options:**
-
-- **`--file FILE`** - YAML file path or GitHub URL to analyze
-  - Can be a local file path or a GitHub URL
-  - When provided, extracts task/step info and runs per-pod data collection (single source), then analysis
-  - Required for initial analysis, optional when using `--update` with cache
-
-- **`--update`** - Phase 2: View recommendations for all base metrics
-  - **Requires `--file`**: Must specify which task to update
-  - Extracts task name from the file and loads analysis data from Phase 1
-  - Shows comparison tables for all base metrics (max, p95, p90, median) - `--base` flag is ignored
-  - **Does NOT update YAML files**: You must update YAML files manually after reviewing recommendations
-  - Creates comparison file for the specified margin if it doesn't exist: `{task_name}_comparison_data_margin-{margin}_{YYYYMMDD}.html/json`
-  - If comparison file already exists for the margin, uses existing file (no new file created)
-  - Can be run multiple times with different `--margin` values, creating separate files for each margin
-  - Multiple margin files coexist for the same analysis date, allowing easy comparison across margins
-  - **No timestamp added** in Phase 2 (timestamp only added when re-analysis happens in Phase 1)
-
-- **`--analyze-again`, `--aa`** - Force re-analysis even when cache exists
-  - Only effective when used with `--update --file`
-  - Ignores existing cache and runs fresh analysis before updating
-  - Useful when you want to re-analyze with different parameters
-
-- **`--margin MARGIN`** - Safety margin percentage to add to base metric (default: 5)
-  - Formula: `recommended = base_metric * (1 + margin / 100)`
-  - Common values: 5% (default), 10% (balanced), 20% (conservative)
-  - Applied to all base metrics (max, p95, p90, median) in both Phase 1 and Phase 2
-  - Final recommendation is capped at maximum observed value
-
-- **`--base {max,p95,p90,median}`** - Base metric for margin calculation (default: max)
-  - **Phase 1 (Analysis)**: This flag is **IGNORED**. All base metrics (max, p95, p90, median) are generated regardless.
-  - **Phase 2 (Update)**: This flag is **IGNORED**. All base metrics are always shown regardless of this flag.
-  - **`max`**: Maximum observed usage across all clusters (most conservative, default)
-  - **`p95`**: 95th percentile usage (recommended for production, covers 95% of cases)
-  - **`p90`**: 90th percentile usage (more aggressive, covers 90% of cases)
-  - **`median`**: Median usage (most aggressive, covers 50% of cases)
-  - Falls back to `max` if selected percentile data is unavailable
-  - The tool finds the maximum of each metric across all clusters, then adds margin
-
-- **`--days DAYS`** - Number of days for data collection when using `--file` (default: 7)
-  - Range: Typically 1-30+ days
-  - Longer periods provide more data but take longer to collect
-  - Shorter periods are faster but may miss periodic spikes
-  - Only used when `--file` is provided (not with piped input)
-
-- **`--debug`** - Enable debug output showing detailed processing information
-  - Shows step detection logic, YAML parsing details
-  - Displays computeResources update operations
-  - Useful for troubleshooting YAML update issues
-  - Can be combined with any other option
-
-- **`--pll-clusters N`** - Enable parallel processing across clusters with N workers
-  - Only active during analysis phase (ignored during `--update`)
-  - Processes N clusters concurrently for faster data collection
-  - Each cluster uses a process-specific kubeconfig to avoid conflicts
-  - Recommended for environments with many clusters (e.g., `--pll-clusters 3` or `--pll-clusters 5`)
-  - Serial mode (default) processes clusters one by one
-
-- **`--dry-run`** - Validate task/steps and check cluster connectivity without running data collection
-  - Validates wrapper-defined steps against YAML file steps
-  - Checks connectivity to all configured clusters
-  - Displays cluster connectivity report
-  - Exits without running data collection or analysis
-  - Useful for troubleshooting configuration issues before full analysis
-
-**How it works:**
-
-**Phase 1: Analysis (default, unless `--update` is specified):**
-
-1. **With `--file` (local or GitHub URL):**
-   - Validates wrapper-defined steps against YAML file steps before proceeding
-   - Checks cluster connectivity and displays connectivity report with short cluster names (e.g., "stone-stg-rh01")
-   - Extracts task name, step names, and current resource limits from Tekton Task YAML
-   - Collects per-pod metrics from all clusters (single source); derives max/p95/p90/median CSV for analysis
-   - Shows data collection output in table format and analyzes data across all clusters for each step
-   - **Generates recommendations for ALL base metrics** (max, p95, p90, median) - `--base` flag is ignored
-   - Calculates recommendations using each base metric + safety margin
-   - Rounds values to standard Kubernetes resource sizes
-   - Saves analyzed data files (sortable HTML + JSON)
-   - Saves detailed per-step files (one HTML/JSON/CSV per step): `{task_name}_analyzed_data_detailed_step_{step-name}_{YYYYMMDD}.html/json/csv` (step names without `step-` prefix, e.g. `prefetch-dependencies`)
-   - Saves comparison data files with margin in filename:
-     - First analysis: `{task_name}_comparison_data_margin-{margin}_{YYYYMMDD}.html/json`
-     - Re-analysis: `{task_name}_comparison_data_margin-{margin}_{YYYYMMDD_HHMMSS}.html/json` (preserves old files)
-   - Shows detailed analysis for default base (max)
-   - Timestamp is only added when re-analysis happens (analyzed_data files exist for that date)
-
-**Phase 2: Update (with `--update` flag):**
-
-2. **With `--update --file`:**
-   - Requires `--file` to specify which task to update
-   - Loads analyzed data from Phase 1 (date-based files, handles both date-only and date+timestamp formats)
-   - Checks if comparison file exists for the specified margin
-   - If comparison file exists: Uses existing file (no new file created)
-   - If comparison file doesn't exist: Creates new comparison file `{task_name}_comparison_data_margin-{margin}_{YYYYMMDD}.html/json` (no timestamp, since no re-analysis)
-   - Shows comparison tables for **all base metrics** (max, p95, p90, median) - `--base` flag is ignored
-   - **Does NOT update YAML files** - you must update them manually
-   - Can be run multiple times with different `--margin` values, creating separate files for each margin
-   - Multiple margin files can coexist for the same analysis date, allowing easy comparison
-   
-3. **With piped input:**
-   - Reads CSV data from stdin
-   - Analyzes and provides recommendations for all base metrics
-   - Does not save files (no file reference)
-
-4. **With `--dry-run`:**
-   - Validates wrapper-defined steps against YAML file steps
-   - Checks connectivity to all configured clusters
-   - Displays cluster connectivity report with short cluster names
-   - Exits without running data collection or analysis
-   - Useful for troubleshooting configuration issues before running full analysis
-
-**Understanding Base Metrics:**
-
-The tool calculates recommendations using a two-step process:
-
-1. **Collect metrics per cluster**: For each step, the tool collects Max, P95, P90, and Median values from each cluster
-2. **Find maximum across clusters**: For the selected base metric, it finds the maximum value across all clusters
-3. **Add safety margin**: Applies the margin percentage to this maximum value
-4. **Cap at observed maximum**: Final recommendation never exceeds the maximum observed value
-
-**Example calculation with `--base p95 --margin 10`:**
-- Cluster A: P95 memory = 2Gi
-- Cluster B: P95 memory = 3Gi  
-- Cluster C: P95 memory = 2.5Gi
-- Maximum P95 across clusters = 3Gi
-- Base for calculation = 3Gi
-- Recommended = 3Gi × (1 + 10/100) = 3.3Gi
-- If max observed memory was 3.5Gi, recommendation is capped at 3.5Gi
-- Final recommendation (after rounding) = 4Gi
-
-**Choosing the Right Base Metric:**
-
-- **`max`** (default): Safest choice, ensures all observed usage patterns are covered. Use for production workloads where reliability is critical.
-- **`p95`**: Recommended for most production workloads. Covers 95% of usage patterns, provides good balance between safety and resource efficiency.
-- **`p90`**: More aggressive, suitable for cost optimization when occasional OOM kills are acceptable. Covers 90% of usage patterns.
-- **`median`**: Most aggressive, only covers 50% of usage patterns. Use only for non-critical workloads or when cost is the primary concern.
-
-**Example Output:**
-
-**Cluster Connectivity Report:**
-```
-================================================================================
-Checking Cluster Connectivity
-================================================================================
-
-Cluster Connectivity Report:
-  ✓ stone-prd-rh01: Connected
-  ✓ kflux-prd-rh02: Connected
-  ✓ kflux-prd-rh03: Connected
-  ✓ stone-prod-p02: Connected
-
-✓ All clusters are accessible
-```
-
-**Data Collection Summary (shown during data collection):**
-```
-================================================================================
-Data Collection Summary
-================================================================================
-Total clusters processed: 4
-Successful: 4
-Failed: 0
-================================================================================
-
-Collected data from 4 cluster(s), total CSV lines: 8
-```
-
-**Analysis Output:**
-```
-================================================================================
-RESOURCE LIMIT RECOMMENDATIONS (Max + 10% Safety Margin)
-================================================================================
-
-Step: step-build
---------------------------------------------------------------------------------
-  Memory: 8Gi
-    - Base (Max): 8.0Gi
-    - Coverage: 6/6 clusters
-
-  CPU: 5100m
-    - Base (Max): 4.67 cores
-    - Coverage: 4/4 clusters
-
-Step: step-push
---------------------------------------------------------------------------------
-  Memory: 1Gi
-    - Base (Max): 1024MB
-    - Coverage: 5/6 clusters
-
-  CPU: 400m
-    - Base (Max): 0.385 cores
-    - Coverage: 5/6 clusters
-```
-
-**Comparison Table Output:**
-```
-========================================================================================================================
-RESOURCE LIMITS COMPARISON: CURRENT vs PROPOSED
-========================================================================================================================
-
-Step                      Current Requests               Proposed Requests              Current Limits                 Proposed Limits               
-------------------------------------------------------------------------------------------------------------------------
-build                     8Gi / 1                        8Gi / 5100m                    8Gi / null                     8Gi / 5100m                   
-push                      4Gi / 1                        1Gi / 400m                     4Gi / null                     1Gi / 400m                    
-sbom-syft-generate        4Gi / 1                        2Gi / 800m                     4Gi / null                     2Gi / 800m                    
-prepare-sboms             512Mi / 100m                   192Mi / 50m                    512Mi / null                   192Mi / 50m                   
-upload-sbom               512Mi / 100m                   64Mi / 50m                     512Mi / null                   64Mi / 50m                  
-```
-
-**Patch File Generation (for remote URLs):**
-When using `--update` with a GitHub URL, a patch file is generated:
-```
-Generated patch file: buildah_20241219_141358.patch
-File path in patch: task/buildah/0.7/buildah.yaml
-Apply with: patch <original_file> < buildah_20241219_141358.patch
-```
-
-**Caching:**
-- Cache files are stored in `.analyze_cache/` directory
-- **Task-based caching**: Each task gets its own cache file based on task name (e.g., `clair-scan.json`, `buildah.json`)
-- This allows multiple independent analyses and updates:
-  - Run analysis on multiple tasks sequentially without overwriting caches
-  - Each task's cache is independent and can be updated separately
-  - Example: Analyze `task1.yaml` → saves to `task1.json`, then analyze `task2.yaml` → saves to `task2.json` (independent)
-- Cache includes: task name, file path/URL, recommendations, margin, base metric, days, and timestamp
-- When using `--update --file <local_file>`: Extracts task name from the file and loads cache for that specific task
-- When using `--update` without `--file`: Shows all available cached tasks and uses the most recent one
-- Use `--analyze-again` flag to force re-analysis even when cache exists for that task
-
-**File Output (Phase 1 - Analysis):**
-- **Date-based naming**: Files use date format (YYYYMMDD) for first analysis, or date+timestamp (YYYYMMDD_HHMMSS) if files already exist for that date
-- **Analyzed Data Files**:
-  - First analysis on a date: `{task_name}_analyzed_data_{YYYYMMDD}.html/json`
-  - Re-running on same date: `{task_name}_analyzed_data_{YYYYMMDD_HHMMSS}.html/json` (preserves old files)
-  - Sortable HTML table and JSON of aggregated CSV data
-- **Detailed per-step files** (one HTML/JSON/CSV per step): `{task_name}_analyzed_data_detailed_step_{step-name}_{YYYYMMDD}.html/json/csv` — step names without `step-` prefix (e.g. `prefetch-dependencies`), sortable tables with current requests/limits in Kubernetes format
-- **Comparison Data Files** (margin-specific, created in both Phase 1 and Phase 2):
-  - **Phase 1 (first analysis)**: `{task_name}_comparison_data_margin-{margin}_{YYYYMMDD}.html/json`
-  - **Phase 1 (re-analysis)**: `{task_name}_comparison_data_margin-{margin}_{YYYYMMDD_HHMMSS}.html/json` (preserves old files)
-  - **Phase 2 (new margin)**: `{task_name}_comparison_data_margin-{margin}_{YYYYMMDD}.html/json` (no timestamp, since no re-analysis)
-  - Comparison tables for all base metrics (max, p95, p90, median)
-  - All recommendations for all base metrics
-  - Each margin gets its own file, allowing multiple margin files to coexist for the same analysis
-  - Files are only created if they don't already exist for that margin
-- **Date Format**: `YYYYMMDD` (e.g., `20250113`) or `YYYYMMDD_HHMMSS` (e.g., `20250113_165921`) when re-analysis happens
-- **File Location**: All files saved in `.analyze_cache/` directory
-- **Task Isolation**: Each task has its own files, allowing parallel/serial analysis of multiple tasks without interference
-- **Margin Isolation**: Each margin has its own comparison file, allowing comparison across different margins
-- **Browser Compatibility**: HTML files work in any modern browser with no external dependencies
-- **Notification**: Tool prints file locations to stderr when files are saved
-
-**Rounding Rules:**
-- **Memory**: 
-  - Minimum: 64Mi
-  - < 1Gi: Rounds UP to next increment of 64Mi (e.g., 65MB → 128Mi, 200MB → 256Mi, 735MB → 768Mi)
-  - >= 1Gi: Rounds UP to next whole Gi (e.g., 1269MB → 2Gi, 2989MB → 3Gi)
-- **CPU**:
-  - Minimum: 50m
-  - Always rounds UP to next increment of 50m (e.g., 51m → 100m, 243m → 250m, 459m → 500m)
-  - Always outputs in millicore format (e.g., `5100m` for 5.1 cores)
-
-**Technical Notes:**
-- **Memory Metrics**: The tool uses `container_memory_working_set_bytes` for all memory calculations (max, p95, p90, median). This metric reflects actual memory usage, not memory limits. This ensures recommendations are based on real usage patterns rather than configured limits.
-- **CPU Metrics**: CPU calculations use `container_cpu_usage_seconds_total` with rate calculations to determine actual CPU consumption over time.
-
-Konflux Cluster Authentication
-===================================
-
-You can use 'oclogin' + 'oclogin-all' utilities shared by Jan Hutar.  
-These automatically generate kubeconfig entries for all Konflux clusters.
-
+- Open an issue or PR in [redhat-appstudio/perfscale](https://github.com/redhat-appstudio/perfscale)
+- Share your findings in `#konflux-users` or `#forum-konflux-build`
+- Run the tool on your own task and share the HTML report — more data from more tenants improves
+  recommendations for everyone

--- a/tools/tasks-and-steps-resource-analyzer/analyze_resource_limits.py
+++ b/tools/tasks-and-steps-resource-analyzer/analyze_resource_limits.py
@@ -422,10 +422,13 @@ def _compute_violators_for_step(detailed_executions, step_name, mem_base, cpu_ba
     return result
 
 
-def _html_violators_block(viol_by_ns, mem_base, cpu_base, base_label, step_display_name):
-    """Render a collapsible HTML block listing executions that exceed a base threshold.
+def _html_violators_block(viol_by_ns, mem_base, cpu_base, base_label, step_display_name,
+                          _table_counter=[0]):
+    """Render a sortable, collapsible HTML block listing executions that exceed a base threshold.
 
-    Uses <details>/<summary> for zero-JS expand/collapse.
+    Produces a flat table (no rowspan) with data-val attributes on the numeric columns so
+    that the sortVT() JavaScript function can sort by Peak Mem, vs Base, Peak CPU, # Pods.
+    Namespace and Application cells keep their coloured backgrounds for visual grouping.
     """
     if not viol_by_ns:
         return (f'<p class="no-violators">&#10003;&nbsp; No executions exceed the '
@@ -440,57 +443,65 @@ def _html_violators_block(viol_by_ns, mem_base, cpu_base, base_label, step_displ
             return '0m'
         return f'{int(c * 1000)}m' if c < 1 else f'{c:.3f}'
 
-    ns_app_count = sum(len(apps) for apps in viol_by_ns.values())
     mem_thr = _fmt_mb(mem_base) if (mem_base and mem_base > 0) else '—'
     cpu_thr = _fmt_cpu(cpu_base) if (cpu_base and cpu_base > 0) else '—'
 
-    rows_html = ''
+    # Flatten nested dict → list of row dicts, sorted by peak mem desc
+    flat_rows = []
     for ns in sorted(viol_by_ns):
-        ns_apps = viol_by_ns[ns]
-        ns_row_count = sum(len(comps) for comps in ns_apps.values())
-        first_ns = True
-        for app in sorted(ns_apps):
-            comps = ns_apps[app]
-            first_app = True
-            for row in comps:
-                mem_over = row['mem_max'] - mem_base if row['mem_viol'] else 0
-                cpu_over = row['cpu_max'] - cpu_base if row['cpu_viol'] else 0
-                mem_vs  = f'+{_fmt_mb(mem_over)}&nbsp;&#9888;' if row['mem_viol'] else '&#10003;&nbsp;ok'
-                cpu_vs  = f'+{_fmt_cpu(cpu_over)}&nbsp;&#9888;' if row['cpu_viol'] else '&#10003;&nbsp;ok'
-                mc = ' class="viol-cell"' if row['mem_viol'] else ''
-                cc = ' class="viol-cell"' if row['cpu_viol'] else ''
-                ns_td  = (f'<td rowspan="{ns_row_count}" class="viol-ns-cell">'
-                          f'{html.escape(ns)}</td>') if first_ns else ''
-                app_td = (f'<td rowspan="{len(comps)}" class="viol-app-cell">'
-                          f'{html.escape(app)}</td>') if first_app else ''
-                rows_html += (
-                    f'<tr>{ns_td}{app_td}'
-                    f'<td>{html.escape(row["component"])}</td>'
-                    f'<td><span class="cluster-badge">{html.escape(row["cluster"])}</span></td>'
-                    f'<td{mc}>{_fmt_mb(row["mem_max"])}</td>'
-                    f'<td{mc}>{mem_vs}</td>'
-                    f'<td{cc}>{_fmt_cpu(row["cpu_max"])}</td>'
-                    f'<td{cc}>{cpu_vs}</td>'
-                    f'<td>{row["count"]}</td>'
-                    f'</tr>\n'
-                )
-                first_ns  = False
-                first_app = False
+        for app in sorted(viol_by_ns[ns]):
+            for row in viol_by_ns[ns][app]:
+                flat_rows.append(dict(row, namespace=ns, application=app))
+    flat_rows.sort(key=lambda r: -r['mem_max'])
+
+    _table_counter[0] += 1
+    tid = f'viol_tbl_{_table_counter[0]}'
+
+    rows_html = ''
+    for row in flat_rows:
+        mem_over = row['mem_max'] - mem_base if row['mem_viol'] else 0
+        cpu_over = row['cpu_max'] - cpu_base if row['cpu_viol'] else 0
+        mem_vs   = f'+{_fmt_mb(mem_over)}&nbsp;&#9888;' if row['mem_viol'] else '&#10003;&nbsp;ok'
+        cpu_vs   = f'+{_fmt_cpu(cpu_over)}&nbsp;&#9888;' if row['cpu_viol'] else '&#10003;&nbsp;ok'
+        mc = ' class="viol-cell"' if row['mem_viol'] else ''
+        cc = ' class="viol-cell"' if row['cpu_viol'] else ''
+        # data-val carries raw numeric value for JS sort:
+        #   mem / cpu → MB or millicores; "ok" rows get -1 so they sort to bottom
+        mem_dv  = f'{row["mem_max"]:.1f}'
+        memov_dv = f'{mem_over:.1f}' if row['mem_viol'] else '-1'
+        cpu_dv  = f'{row["cpu_max"] * 1000:.1f}'
+        cpuov_dv = f'{cpu_over * 1000:.1f}' if row['cpu_viol'] else '-1'
+        rows_html += (
+            f'<tr>'
+            f'<td class="viol-ns-cell">{html.escape(row["namespace"])}</td>'
+            f'<td class="viol-app-cell">{html.escape(row["application"])}</td>'
+            f'<td>{html.escape(row["component"])}</td>'
+            f'<td><span class="cluster-badge">{html.escape(row["cluster"])}</span></td>'
+            f'<td{mc} data-val="{mem_dv}">{_fmt_mb(row["mem_max"])}</td>'
+            f'<td{mc} data-val="{memov_dv}">{mem_vs}</td>'
+            f'<td{cc} data-val="{cpu_dv}">{_fmt_cpu(row["cpu_max"])}</td>'
+            f'<td{cc} data-val="{cpuov_dv}">{cpu_vs}</td>'
+            f'<td data-val="{row["count"]}">{row["count"]}</td>'
+            f'</tr>\n'
+        )
 
     return f"""<details class="violators-block">
   <summary class="violators-summary">
-    &#9888;&nbsp; <strong>{ns_app_count}&nbsp;namespace&#8209;app&nbsp;group(s)</strong>
+    &#9888;&nbsp; <strong>{len(flat_rows)}&nbsp;group(s)</strong>
     exceed the <em>{base_label}</em> baseline
     ({mem_thr}&nbsp;mem&nbsp;/&nbsp;{cpu_thr}&nbsp;cpu) for step
     <strong>{html.escape(step_display_name)}</strong>&nbsp;&#9660;
   </summary>
   <div class="violators-body">
-    <table class="violators-table">
+    <p class="sort-hint">Click amber column header to sort &nbsp;&#8597;</p>
+    <table id="{tid}" class="violators-table">
       <thead><tr>
         <th>Namespace</th><th>Application</th><th>Component</th><th>Cluster</th>
-        <th>Peak Mem</th><th>vs&nbsp;Base&nbsp;(Mem)</th>
-        <th>Peak CPU</th><th>vs&nbsp;Base&nbsp;(CPU)</th>
-        <th>#&nbsp;Pods</th>
+        <th class="sortable" onclick="sortVT('{tid}',4)">Peak&nbsp;Mem</th>
+        <th class="sortable" onclick="sortVT('{tid}',5)">vs&nbsp;Base&nbsp;(Mem)</th>
+        <th class="sortable" onclick="sortVT('{tid}',6)">Peak&nbsp;CPU</th>
+        <th class="sortable" onclick="sortVT('{tid}',7)">vs&nbsp;Base&nbsp;(CPU)</th>
+        <th class="sortable" onclick="sortVT('{tid}',8)">#&nbsp;Pods</th>
       </tr></thead>
       <tbody>{rows_html}</tbody>
     </table>
@@ -2554,13 +2565,11 @@ def save_comparison_data_all_bases(task_name, all_recommendations_by_base, curre
         td.viol-ns-cell {{
             font-weight: bold;
             color: #1565c0;
-            vertical-align: top;
             border-right: 2px solid #bbdefb;
             background: #e3f2fd;
         }}
         td.viol-app-cell {{
             color: #2e7d32;
-            vertical-align: top;
             border-right: 1px solid #c8e6c9;
             background: #f1f8f1;
         }}
@@ -2573,7 +2582,39 @@ def save_comparison_data_all_bases(task_name, all_recommendations_by_base, curre
             border-radius: 3px;
             white-space: nowrap;
         }}
+        /* sortable violators column headers */
+        table.violators-table th.sortable {{
+            cursor: pointer;
+            user-select: none;
+            white-space: nowrap;
+            background: #ffe082;
+        }}
+        table.violators-table th.sortable:hover {{ background: #ffd54f; }}
+        table.violators-table th.sort-asc::after  {{ content: " ↑"; font-weight: bold; }}
+        table.violators-table th.sort-desc::after {{ content: " ↓"; font-weight: bold; }}
+        .sort-hint {{ font-size: 0.78em; color: #888; margin: 4px 0 6px 0; }}
     </style>
+    <script>
+    function sortVT(tableId, colIdx) {{
+        var tbl   = document.getElementById(tableId);
+        var ths   = tbl.querySelectorAll('thead th');
+        var tbody = tbl.querySelector('tbody');
+        var rows  = Array.from(tbody.querySelectorAll('tr'));
+        var th    = ths[colIdx];
+        var asc   = th.classList.contains('sort-desc');
+        ths.forEach(function(h) {{ h.classList.remove('sort-asc', 'sort-desc'); }});
+        rows.sort(function(a, b) {{
+            var av = parseFloat(a.cells[colIdx].getAttribute('data-val'));
+            var bv = parseFloat(b.cells[colIdx].getAttribute('data-val'));
+            if (!isNaN(av) && !isNaN(bv)) return asc ? av - bv : bv - av;
+            var at = a.cells[colIdx].textContent.trim();
+            var bt = b.cells[colIdx].textContent.trim();
+            return asc ? at.localeCompare(bt) : bt.localeCompare(at);
+        }});
+        rows.forEach(function(r) {{ tbody.appendChild(r); }});
+        th.classList.add(asc ? 'sort-asc' : 'sort-desc');
+    }}
+    </script>
 </head>
 <body>
     <h1>Resource Limits Comparison: Current vs Proposed</h1>

--- a/tools/tasks-and-steps-resource-analyzer/analyze_resource_limits.py
+++ b/tools/tasks-and-steps-resource-analyzer/analyze_resource_limits.py
@@ -159,6 +159,346 @@ def _html_steps_missing_observability_banner(steps_missing):
     )
 
 
+# ---------------------------------------------------------------------------
+# Finding 2: Cluster data coverage window
+# ---------------------------------------------------------------------------
+
+def compute_cluster_coverage_report(detailed_executions, days_requested):
+    """Compute the actual data coverage window per cluster from collected executions.
+
+    Returns a dict keyed by cluster display name:
+        {cluster: {'oldest_date': str, 'days_covered': float, 'meets_requested': bool, 'pod_count': int}}
+    """
+    if not detailed_executions:
+        return {}
+
+    import math
+    now = datetime.now()
+    by_cluster = defaultdict(list)
+    for e in detailed_executions:
+        cluster = e.get('cluster', 'unknown')
+        ts = e.get('timestamp', '')
+        if ts:
+            by_cluster[cluster].append(ts)
+
+    report = {}
+    for cluster, timestamps in by_cluster.items():
+        valid_ts = []
+        for ts in timestamps:
+            try:
+                dt = datetime.strptime(ts, '%Y-%m-%d %H:%M:%S')
+                valid_ts.append(dt)
+            except (ValueError, TypeError):
+                pass
+        if not valid_ts:
+            continue
+        oldest = min(valid_ts)
+        days_covered = (now - oldest).total_seconds() / 86400.0
+        report[cluster] = {
+            'oldest_date': oldest.strftime('%Y-%m-%d %H:%M:%S'),
+            'days_covered': round(days_covered, 1),
+            'meets_requested': days_covered >= (days_requested * 0.9),  # 10% tolerance
+            'pod_count': len(timestamps),
+        }
+    return report
+
+
+def _html_cluster_coverage_banner(coverage_report, days_requested):
+    """HTML banner showing actual data coverage per cluster."""
+    if not coverage_report:
+        return ''
+
+    rows = ''
+    has_warning = False
+    for cluster in sorted(coverage_report.keys()):
+        info = coverage_report[cluster]
+        days = info['days_covered']
+        meets = info['meets_requested']
+        oldest = info['oldest_date']
+        pods = info['pod_count']
+        if not meets:
+            has_warning = True
+            icon = '&#9888;'  # warning triangle
+            row_style = 'color:#856404;background:#fff3cd;'
+        else:
+            icon = '&#10003;'  # check mark
+            row_style = 'color:#155724;'
+        rows += (
+            f'<tr style="{row_style}">'
+            f'<td style="padding:4px 10px;">{html.escape(cluster)}</td>'
+            f'<td style="padding:4px 10px;">{icon} {days:.1f} days</td>'
+            f'<td style="padding:4px 10px;">{oldest}</td>'
+            f'<td style="padding:4px 10px;">{pods}</td>'
+            f'</tr>\n'
+        )
+
+    border_color = '#ffc107' if has_warning else '#28a745'
+    bg_color = '#fff3cd' if has_warning else '#d4edda'
+    heading = (
+        f'&#9888; Some clusters returned less data than the requested {days_requested} days — '
+        'statistics may under-represent rare heavy workloads on those clusters.'
+        if has_warning else
+        f'&#10003; All clusters returned data covering the full {days_requested}-day window.'
+    )
+
+    return (
+        f'    <div style="background:{bg_color};border:1px solid {border_color};padding:12px 16px;'
+        f'margin:16px 0;border-radius:4px;">\n'
+        f'        <strong>Cluster Data Coverage Report</strong> (requested: {days_requested} days)<br>\n'
+        f'        <em style="font-size:0.9em;color:#555;">{heading}</em>\n'
+        f'        <table style="margin-top:8px;border-collapse:collapse;font-size:0.9em;">\n'
+        f'          <tr style="font-weight:bold;">'
+        f'<td style="padding:4px 10px;">Cluster</td>'
+        f'<td style="padding:4px 10px;">Coverage</td>'
+        f'<td style="padding:4px 10px;">Oldest Data Point</td>'
+        f'<td style="padding:4px 10px;">Pod Executions</td></tr>\n'
+        f'{rows}'
+        f'        </table>\n'
+        f'    </div>\n'
+    )
+
+
+# ---------------------------------------------------------------------------
+# Finding 3: Scrape-interval transparency and heavy-tail warnings
+# ---------------------------------------------------------------------------
+
+def _html_scrape_interval_note():
+    """HTML advisory about Prometheus scrape interval and sub-scrape memory spikes."""
+    return (
+        '    <div style="background:#e8f4fd;border:1px solid #90caf9;padding:12px 16px;'
+        'margin:16px 0;border-radius:4px;">\n'
+        '        <strong>&#8505; Prometheus Scrape Interval Notice</strong>\n'
+        '        <p style="margin:8px 0 0 0;font-size:0.95em;color:#333;">'
+        'Memory values are the <em>maximum of all scraped samples</em> within the analysis window. '
+        'The Prometheus scrape interval for <code>container_memory_working_set_bytes</code> is '
+        'typically <strong>15&ndash;30 seconds</strong> on Konflux clusters. A transient memory spike '
+        'that resolves faster than one scrape interval (e.g. a brief image-decompression burst) '
+        'will <strong>not</strong> appear in the data. Steps that perform large, short-lived memory '
+        'allocations (image pulls, decompression, GC) may have actual peak usage higher than reported. '
+        'For long-term improvement, Splunk-archived metrics at higher resolution can be used to '
+        'cross-check Prometheus data.</p>\n'
+        '    </div>\n'
+    )
+
+
+def compute_heavy_tail_warnings(all_recommendations_by_base):
+    """Return per-step heavy-tail warnings when max/p95 ratio exceeds threshold.
+
+    Returns a list of dicts:
+        [{'step': str, 'mem_max_mb': float, 'mem_p95_mb': float, 'ratio': float,
+          'p99_mb': float (if available), 'cpu_max': float, 'cpu_p95': float}]
+    """
+    RATIO_WARN = 3.0
+    warnings = []
+    max_recs = all_recommendations_by_base.get('max', [])
+    p95_recs = all_recommendations_by_base.get('p95', [])
+
+    p95_by_step = {r['step_name']: r for r in p95_recs if r}
+    for rec in max_recs:
+        if not rec:
+            continue
+        step = rec['step_name']
+        mem_max = rec.get('mem_max_max', 0)
+        p95_rec = p95_by_step.get(step)
+        mem_p95 = p95_rec.get('mem_p95_max', 0) if p95_rec else rec.get('mem_p95_max', 0)
+        cpu_max = rec.get('cpu_max_max', 0)
+        cpu_p95 = p95_rec.get('cpu_p95_max', 0) if p95_rec else rec.get('cpu_p95_max', 0)
+        if mem_p95 > 0 and mem_max / mem_p95 >= RATIO_WARN:
+            warnings.append({
+                'step': step,
+                'mem_max_mb': mem_max,
+                'mem_p95_mb': mem_p95,
+                'ratio': round(mem_max / mem_p95, 1),
+                'cpu_max_cores': cpu_max,
+                'cpu_p95_cores': cpu_p95,
+            })
+    return warnings
+
+
+def _html_heavy_tail_warnings_banner(warnings):
+    """HTML banner surfacing heavy-tail distribution warnings for reviewers."""
+    if not warnings:
+        return ''
+
+    rows = ''
+    for w in warnings:
+        mem_max_k8s = mb_to_kubernetes(w['mem_max_mb'])
+        mem_p95_k8s = mb_to_kubernetes(w['mem_p95_mb'])
+        rows += (
+            f'<tr>'
+            f'<td style="padding:5px 10px;font-weight:bold;">{html.escape(normalize_step_name_for_compare(w["step"]))}</td>'
+            f'<td style="padding:5px 10px;">{mem_max_k8s} ({w["mem_max_mb"]:.0f} MB)</td>'
+            f'<td style="padding:5px 10px;">{mem_p95_k8s} ({w["mem_p95_mb"]:.0f} MB)</td>'
+            f'<td style="padding:5px 10px;color:#c62828;font-weight:bold;">{w["ratio"]}&#215;</td>'
+            f'</tr>\n'
+        )
+
+    return (
+        '    <div style="background:#fff8e1;border:2px solid #f9a825;padding:12px 16px;'
+        'margin:16px 0;border-radius:4px;">\n'
+        '        <strong>&#9888; Heavy-Tail Distribution Warning</strong>\n'
+        '        <p style="margin:8px 0 4px 0;font-size:0.95em;color:#555;">'
+        'The following step(s) show a Max/P95 memory ratio &ge; 3&times;. '
+        'This means rare but heavy workloads (outlier tenants, large bundles) can require '
+        'significantly more memory than the p95 recommendation covers. '
+        'Consider using the <strong>MAX</strong> base or a per-tenant resource override '
+        'for these steps if OOM failures occur on outlier workloads.</p>\n'
+        '        <table style="border-collapse:collapse;font-size:0.9em;margin-top:8px;">\n'
+        '          <tr style="font-weight:bold;background:#fef9c3;">'
+        '<td style="padding:5px 10px;">Step</td>'
+        '<td style="padding:5px 10px;">Max Observed</td>'
+        '<td style="padding:5px 10px;">P95</td>'
+        '<td style="padding:5px 10px;">Max/P95 Ratio</td></tr>\n'
+        f'{rows}'
+        '        </table>\n'
+        '    </div>\n'
+    )
+
+
+def _compute_violators_for_step(detailed_executions, step_name, mem_base, cpu_base):
+    """Find pod executions that exceed a given memory or CPU base threshold for one step.
+
+    Groups results as: namespace → application → list-of-component-dicts.
+
+    Returns:
+        dict  { namespace: { application: [ {component, cluster, mem_max, cpu_max,
+                                              count, mem_viol, cpu_viol} ] } }
+        or empty dict if there are no violations.
+    """
+    from collections import defaultdict as _dd
+
+    # Only violations make sense when there is a non-zero base
+    has_mem_base = mem_base and mem_base > 0
+    has_cpu_base = cpu_base and cpu_base > 0
+    if not has_mem_base and not has_cpu_base:
+        return {}
+
+    # Normalise the step name we look for (executions may carry it without 'step-' prefix)
+    step_bare = step_name.removeprefix('step-') if step_name.startswith('step-') else step_name
+
+    groups = _dd(lambda: {'mem_vals': [], 'cpu_vals': []})
+    for r in detailed_executions:
+        r_step = r.get('step', '')
+        r_step_bare = r_step.removeprefix('step-') if r_step.startswith('step-') else r_step
+        if r_step_bare != step_bare:
+            continue
+        mem = float(r.get('memory_mb', 0) or 0)
+        cpu = float(r.get('cpu_cores', 0) or 0)
+        mem_viol = has_mem_base and mem > mem_base
+        cpu_viol = has_cpu_base and cpu > cpu_base
+        if not (mem_viol or cpu_viol):
+            continue
+        key = (
+            r.get('namespace', 'unknown'),
+            r.get('application', 'unknown'),
+            r.get('component', 'unknown'),
+            r.get('cluster', 'unknown'),
+        )
+        groups[key]['mem_vals'].append(mem)
+        groups[key]['cpu_vals'].append(cpu)
+
+    if not groups:
+        return {}
+
+    result = _dd(lambda: _dd(list))
+    for (ns, app, comp, cluster), vals in groups.items():
+        mem_max = max(vals['mem_vals']) if vals['mem_vals'] else 0
+        cpu_max = max(vals['cpu_vals']) if vals['cpu_vals'] else 0
+        result[ns][app].append({
+            'component': comp,
+            'cluster':   cluster,
+            'mem_max':   mem_max,
+            'cpu_max':   cpu_max,
+            'count':     len(vals['mem_vals']),
+            'mem_viol':  has_mem_base and mem_max > mem_base,
+            'cpu_viol':  has_cpu_base and cpu_max > cpu_base,
+        })
+
+    # Sort components within each app by descending peak memory
+    for ns in result:
+        for app in result[ns]:
+            result[ns][app].sort(key=lambda x: -x['mem_max'])
+
+    return result
+
+
+def _html_violators_block(viol_by_ns, mem_base, cpu_base, base_label, step_display_name):
+    """Render a collapsible HTML block listing executions that exceed a base threshold.
+
+    Uses <details>/<summary> for zero-JS expand/collapse.
+    """
+    if not viol_by_ns:
+        return (f'<p class="no-violators">&#10003;&nbsp; No executions exceed the '
+                f'<em>{base_label}</em> baseline for step '
+                f'<strong>{html.escape(step_display_name)}</strong>.</p>\n')
+
+    def _fmt_mb(mb):
+        return f'{mb / 1024:.2f} Gi' if mb >= 1024 else f'{mb:.0f} Mi'
+
+    def _fmt_cpu(c):
+        if c == 0:
+            return '0m'
+        return f'{int(c * 1000)}m' if c < 1 else f'{c:.3f}'
+
+    ns_app_count = sum(len(apps) for apps in viol_by_ns.values())
+    mem_thr = _fmt_mb(mem_base) if (mem_base and mem_base > 0) else '—'
+    cpu_thr = _fmt_cpu(cpu_base) if (cpu_base and cpu_base > 0) else '—'
+
+    rows_html = ''
+    for ns in sorted(viol_by_ns):
+        ns_apps = viol_by_ns[ns]
+        ns_row_count = sum(len(comps) for comps in ns_apps.values())
+        first_ns = True
+        for app in sorted(ns_apps):
+            comps = ns_apps[app]
+            first_app = True
+            for row in comps:
+                mem_over = row['mem_max'] - mem_base if row['mem_viol'] else 0
+                cpu_over = row['cpu_max'] - cpu_base if row['cpu_viol'] else 0
+                mem_vs  = f'+{_fmt_mb(mem_over)}&nbsp;&#9888;' if row['mem_viol'] else '&#10003;&nbsp;ok'
+                cpu_vs  = f'+{_fmt_cpu(cpu_over)}&nbsp;&#9888;' if row['cpu_viol'] else '&#10003;&nbsp;ok'
+                mc = ' class="viol-cell"' if row['mem_viol'] else ''
+                cc = ' class="viol-cell"' if row['cpu_viol'] else ''
+                ns_td  = (f'<td rowspan="{ns_row_count}" class="viol-ns-cell">'
+                          f'{html.escape(ns)}</td>') if first_ns else ''
+                app_td = (f'<td rowspan="{len(comps)}" class="viol-app-cell">'
+                          f'{html.escape(app)}</td>') if first_app else ''
+                rows_html += (
+                    f'<tr>{ns_td}{app_td}'
+                    f'<td>{html.escape(row["component"])}</td>'
+                    f'<td><span class="cluster-badge">{html.escape(row["cluster"])}</span></td>'
+                    f'<td{mc}>{_fmt_mb(row["mem_max"])}</td>'
+                    f'<td{mc}>{mem_vs}</td>'
+                    f'<td{cc}>{_fmt_cpu(row["cpu_max"])}</td>'
+                    f'<td{cc}>{cpu_vs}</td>'
+                    f'<td>{row["count"]}</td>'
+                    f'</tr>\n'
+                )
+                first_ns  = False
+                first_app = False
+
+    return f"""<details class="violators-block">
+  <summary class="violators-summary">
+    &#9888;&nbsp; <strong>{ns_app_count}&nbsp;namespace&#8209;app&nbsp;group(s)</strong>
+    exceed the <em>{base_label}</em> baseline
+    ({mem_thr}&nbsp;mem&nbsp;/&nbsp;{cpu_thr}&nbsp;cpu) for step
+    <strong>{html.escape(step_display_name)}</strong>&nbsp;&#9660;
+  </summary>
+  <div class="violators-body">
+    <table class="violators-table">
+      <thead><tr>
+        <th>Namespace</th><th>Application</th><th>Component</th><th>Cluster</th>
+        <th>Peak Mem</th><th>vs&nbsp;Base&nbsp;(Mem)</th>
+        <th>Peak CPU</th><th>vs&nbsp;Base&nbsp;(CPU)</th>
+        <th>#&nbsp;Pods</th>
+      </tr></thead>
+      <tbody>{rows_html}</tbody>
+    </table>
+  </div>
+</details>
+"""
+
+
 def read_wrapper_config(wrapper_path):
     """Read TASK_NAME and STEPS from wrapper script.
     
@@ -1650,7 +1990,8 @@ def check_comparison_file_exists_for_margin(task_name, date_str, margin_pct):
     return len(matching_files) > 0
 
 
-def save_analyzed_data(task_name, csv_data, date_str, steps_without_observability_data=None):
+def save_analyzed_data(task_name, csv_data, date_str, steps_without_observability_data=None,
+                       cluster_coverage_report=None, days_requested=None):
     """Save analyzed data (CSV) as HTML and JSON files.
     
     Args:
@@ -1658,6 +1999,8 @@ def save_analyzed_data(task_name, csv_data, date_str, steps_without_observabilit
         csv_data: CSV data string
         date_str: Date string in YYYYMMDD format
         steps_without_observability_data: Optional list of YAML step names with no Prometheus rows
+        cluster_coverage_report: Optional dict from compute_cluster_coverage_report()
+        days_requested: Number of days requested (for coverage banner)
     
     Returns:
         tuple: (html_path, json_path) - paths to saved files
@@ -1681,7 +2024,9 @@ def save_analyzed_data(task_name, csv_data, date_str, steps_without_observabilit
             headers = [h.strip().strip('"') for h in rows[0]]
             data_rows = rows[1:] if len(rows) > 1 else []
             banner_html = _html_steps_missing_observability_banner(steps_without_observability_data)
-            
+            coverage_banner = _html_cluster_coverage_banner(cluster_coverage_report or {}, days_requested or 0)
+            scrape_note = _html_scrape_interval_note()
+
             html_content = f"""<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -1777,7 +2122,7 @@ def save_analyzed_data(task_name, csv_data, date_str, steps_without_observabilit
 <body>
     <h1>Resource Usage Data - {task_name}</h1>
     <div class="info">Generated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}</div>
-{banner_html}    <table id="dataTable">
+{coverage_banner}{scrape_note}{banner_html}    <table id="dataTable">
         <thead>
             <tr>
 """
@@ -1815,6 +2160,8 @@ def save_analyzed_data(task_name, csv_data, date_str, steps_without_observabilit
         'timestamp': datetime.now().isoformat(),
         'csv_data': csv_data,
         'steps_without_observability_data': list(steps_without_observability_data or []),
+        'cluster_coverage_report': cluster_coverage_report or {},
+        'days_requested': days_requested or 0,
     }
     
     with open(json_path, 'w', encoding='utf-8') as f:
@@ -1844,7 +2191,7 @@ def _write_one_step_detailed_files(cache_dir, task_name, step_name, step_executi
     csv_path = cache_dir / f"{base}.csv"
 
     table_id = f"table_{safe_step_name}"
-    # Numeric columns for sort: 7 = Final Memory, 10 = Final CPU
+    # Numeric columns for sort: 7 = Final Memory, 10 = Final CPU, 11 = I/O Read, 12 = I/O Write
     html_content = f"""<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -1865,6 +2212,7 @@ def _write_one_step_detailed_files(cache_dir, task_name, step_name, step_executi
         td {{ padding: 10px; border-bottom: 1px solid #ddd; }}
         tr:hover {{ background-color: #f5f5f5; }}
         tr:nth-child(even) {{ background-color: #f9f9f9; }}
+        .io-high {{ background-color: #fff3cd !important; font-weight: bold; }}
     </style>
     <script>
         function sortTable(tableId, columnIndex) {{
@@ -1873,7 +2221,7 @@ def _write_one_step_detailed_files(cache_dir, task_name, step_name, step_executi
             const rows = Array.from(tbody.querySelectorAll('tr'));
             const header = table.querySelectorAll('th')[columnIndex];
             const isAscending = header.classList.contains('sorted-asc');
-            const isNumeric = (columnIndex === 7 || columnIndex === 10);
+            const isNumeric = (columnIndex === 7 || columnIndex === 10 || columnIndex === 11 || columnIndex === 12);
             table.querySelectorAll('th').forEach(th => th.classList.remove('sorted-asc', 'sorted-desc'));
             rows.sort((a, b) => {{
                 const aText = a.cells[columnIndex].textContent.trim();
@@ -1910,20 +2258,26 @@ def _write_one_step_detailed_files(cache_dir, task_name, step_name, step_executi
                 <th onclick="sortTable('{table_id}', 8)">Current Mem requests</th>
                 <th onclick="sortTable('{table_id}', 9)">Current Mem Limits</th>
                 <th onclick="sortTable('{table_id}', 10)">Final CPU Usage (Cores)</th>
-                <th onclick="sortTable('{table_id}', 11)">Current CPU requests</th>
-                <th onclick="sortTable('{table_id}', 12)">Current CPU Limits</th>
-                <th onclick="sortTable('{table_id}', 13)">Timestamp</th>
+                <th onclick="sortTable('{table_id}', 11)">Peak Disk Read (MB/s)</th>
+                <th onclick="sortTable('{table_id}', 12)">Peak Disk Write (MB/s)</th>
+                <th onclick="sortTable('{table_id}', 13)">Current CPU requests</th>
+                <th onclick="sortTable('{table_id}', 14)">Current CPU Limits</th>
+                <th onclick="sortTable('{table_id}', 15)">Timestamp</th>
             </tr>
         </thead>
         <tbody>
 """
+    IO_HIGH_THRESHOLD_MBPS = 50.0  # highlight rows where I/O exceeds this value
     for exec_data in sorted(step_executions, key=lambda x: (x.get('cluster', ''), x.get('namespace', ''), x.get('timestamp', ''))):
         app = exec_data.get('application', 'N/A')
         mem_req = exec_data.get('mem_requests_k8s', 'N/A')
         mem_lim = exec_data.get('mem_limits_k8s', 'N/A')
         cpu_req = exec_data.get('cpu_requests_k8s', 'N/A')
         cpu_lim = exec_data.get('cpu_limits_k8s', 'N/A')
-        html_content += f"""        <tr>
+        io_read = exec_data.get('io_read_mbps', 0)
+        io_write = exec_data.get('io_write_mbps', 0)
+        io_class = ' class="io-high"' if (io_read >= IO_HIGH_THRESHOLD_MBPS or io_write >= IO_HIGH_THRESHOLD_MBPS) else ''
+        html_content += f"""        <tr{io_class}>
             <td>{exec_data.get('cluster', 'N/A')}</td>
             <td>{exec_data.get('namespace', 'N/A')}</td>
             <td>{exec_data.get('task', 'N/A')}</td>
@@ -1935,6 +2289,8 @@ def _write_one_step_detailed_files(cache_dir, task_name, step_name, step_executi
             <td>{mem_req}</td>
             <td>{mem_lim}</td>
             <td>{exec_data.get('cpu_cores', 0)}</td>
+            <td>{io_read}</td>
+            <td>{io_write}</td>
             <td>{cpu_req}</td>
             <td>{cpu_lim}</td>
             <td>{exec_data.get('timestamp', 'N/A')}</td>
@@ -1962,7 +2318,8 @@ def _write_one_step_detailed_files(cache_dir, task_name, step_name, step_executi
 
     csv_header = ('"cluster","namespace","task","step","component","application","pod",'
                   '"final_memory_mb","current_mem_requests","current_mem_limits",'
-                  '"final_cpu_cores","current_cpu_requests","current_cpu_limits","timestamp"')
+                  '"final_cpu_cores","io_read_mbps","io_write_mbps",'
+                  '"current_cpu_requests","current_cpu_limits","timestamp"')
     csv_lines = [csv_header]
     for exec_data in step_executions:
         csv_lines.append(
@@ -1977,6 +2334,8 @@ def _write_one_step_detailed_files(cache_dir, task_name, step_name, step_executi
             f'"{exec_data.get("mem_requests_k8s", "N/A")}",'
             f'"{exec_data.get("mem_limits_k8s", "N/A")}",'
             f'{exec_data.get("cpu_cores", 0)},'
+            f'{exec_data.get("io_read_mbps", 0)},'
+            f'{exec_data.get("io_write_mbps", 0)},'
             f'"{exec_data.get("cpu_requests_k8s", "N/A")}",'
             f'"{exec_data.get("cpu_limits_k8s", "N/A")}",'
             f'"{exec_data.get("timestamp", "")}"'
@@ -2062,7 +2421,9 @@ def split_existing_detailed_per_step_json_to_per_step_files(json_path):
 
 
 def save_comparison_data_all_bases(task_name, all_recommendations_by_base, current_resources, margin_pct, date_str, use_timestamp=False,
-                                    steps_without_observability_data=None):
+                                    steps_without_observability_data=None,
+                                    cluster_coverage_report=None, days_requested=None,
+                                    detailed_executions=None):
     """Save comparison data for all base metrics as HTML and JSON.
     
     Args:
@@ -2073,6 +2434,9 @@ def save_comparison_data_all_bases(task_name, all_recommendations_by_base, curre
         date_str: Date string in YYYYMMDD format
         use_timestamp: If True, add timestamp to filename (used when re-analysis happens in Phase 1)
         steps_without_observability_data: Optional list of YAML steps with no Prometheus rows (Phase 1 only)
+        cluster_coverage_report: Optional dict from compute_cluster_coverage_report()
+        days_requested: Number of days requested (for coverage banner)
+        detailed_executions: Optional list of per-pod execution dicts (enables violators sub-tables)
     
     Returns:
         tuple: (html_path, json_path) - paths to saved files
@@ -2088,6 +2452,10 @@ def save_comparison_data_all_bases(task_name, all_recommendations_by_base, curre
         json_path = get_date_based_file_path(task_name, 'comparison_data', date_str, margin_pct=margin_pct).with_suffix('.json')
     
     banner_cmp = _html_steps_missing_observability_banner(steps_without_observability_data or [])
+    coverage_banner = _html_cluster_coverage_banner(cluster_coverage_report or {}, days_requested or 0)
+    tail_warnings = compute_heavy_tail_warnings(all_recommendations_by_base)
+    tail_banner = _html_heavy_tail_warnings_banner(tail_warnings)
+    scrape_note = _html_scrape_interval_note()
     # Generate HTML with separate tables for each base metric
     html_content = f"""<!DOCTYPE html>
 <html lang="en">
@@ -2116,28 +2484,94 @@ def save_comparison_data_all_bases(task_name, all_recommendations_by_base, curre
             margin-bottom: 20px;
             color: #666;
         }}
-        table {{
+        /* main comparison table */
+        table.main-cmp {{
             border-collapse: collapse;
             width: 100%;
             background-color: white;
             box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-            margin-bottom: 30px;
+            margin-bottom: 4px;
         }}
-        th {{
+        table.main-cmp th {{
             background-color: #2196F3;
             color: white;
-            padding: 12px;
+            padding: 11px 12px;
             text-align: left;
         }}
-        td {{
-            padding: 10px;
+        table.main-cmp td {{
+            padding: 10px 12px;
             border-bottom: 1px solid #ddd;
         }}
-        tr:hover {{
-            background-color: #f5f5f5;
+        table.main-cmp tr:hover {{ background-color: #f0f7ff; }}
+        table.main-cmp tr:nth-child(even) {{ background-color: #f9f9f9; }}
+
+        /* violators collapsible block */
+        details.violators-block {{
+            background: #fffbf0;
+            border: 1px solid #ffe082;
+            border-radius: 4px;
+            margin-bottom: 20px;
         }}
-        tr:nth-child(even) {{
-            background-color: #f9f9f9;
+        summary.violators-summary {{
+            cursor: pointer;
+            padding: 8px 14px;
+            font-size: 0.92em;
+            color: #7b4f00;
+            list-style: none;
+            user-select: none;
+        }}
+        summary.violators-summary::-webkit-details-marker {{ display: none; }}
+        summary.violators-summary:hover {{ background: #fff3cd; border-radius: 4px; }}
+        .violators-body {{ padding: 0 14px 14px; }}
+        .no-violators {{
+            color: #388e3c;
+            font-size: 0.88em;
+            padding: 4px 0 16px 2px;
+            font-style: italic;
+            margin: 0 0 16px 0;
+        }}
+
+        /* violators inner table */
+        table.violators-table {{
+            border-collapse: collapse;
+            width: 100%;
+            font-size: 0.88em;
+            background: white;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+        }}
+        table.violators-table th {{
+            background: #fff3cd;
+            color: #5d4037;
+            padding: 8px 10px;
+            text-align: left;
+            border-bottom: 2px solid #ffe082;
+        }}
+        table.violators-table td {{
+            padding: 7px 10px;
+            border-bottom: 1px solid #f0f0f0;
+            vertical-align: middle;
+        }}
+        td.viol-ns-cell {{
+            font-weight: bold;
+            color: #1565c0;
+            vertical-align: top;
+            border-right: 2px solid #bbdefb;
+            background: #e3f2fd;
+        }}
+        td.viol-app-cell {{
+            color: #2e7d32;
+            vertical-align: top;
+            border-right: 1px solid #c8e6c9;
+            background: #f1f8f1;
+        }}
+        td.viol-cell {{ color: #c62828; font-weight: bold; }}
+        .cluster-badge {{
+            background: #e8eaf6;
+            color: #303f9f;
+            font-size: 0.82em;
+            padding: 2px 6px;
+            border-radius: 3px;
+            white-space: nowrap;
         }}
     </style>
 </head>
@@ -2146,41 +2580,40 @@ def save_comparison_data_all_bases(task_name, all_recommendations_by_base, curre
     <div class="info">Task: {task_name}</div>
     <div class="info">Margin: {margin_pct}%</div>
     <div class="info">Generated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}</div>
-{banner_cmp}
+{coverage_banner}{tail_banner}{scrape_note}{banner_cmp}
 """
-    
-    # Generate table for each base metric
+
+    # Generate table + violators for each base metric
     for base in ['max', 'p95', 'p90', 'median']:
         recommendations = all_recommendations_by_base.get(base, [])
         if not recommendations:
             continue
-        
+
         base_label = base.upper() if base != 'max' else 'MAX'
         html_content += f"""
     <h2>Base Metric: {base_label} (Margin: {margin_pct}%)</h2>
-    <table>
+    <table class="main-cmp">
         <thead>
             <tr>
                 <th>Step</th>
-                <th>Current Requests</th>
-                <th>Proposed Requests</th>
-                <th>Current Limits</th>
-                <th>Proposed Limits</th>
+                <th>Current Requests<br><small>(mem / cpu)</small></th>
+                <th>Proposed Requests<br><small>(mem / cpu)</small></th>
+                <th>Current Limits<br><small>(mem / cpu)</small></th>
+                <th>Proposed Limits<br><small>(mem / cpu)</small></th>
             </tr>
         </thead>
         <tbody>
 """
-        
+
         for rec in recommendations:
             if rec is None:
                 continue
-            
+
             step_name = rec['step_name']
             step_name_yaml = normalize_step_name_for_compare(step_name)
             proposed_mem = rec['mem_recommended_k8s']
             proposed_cpu = rec['cpu_recommended_k8s']
-            
-            # Get current values
+
             if current_resources and step_name_yaml in current_resources:
                 curr = current_resources[step_name_yaml]
                 curr_mem_req = curr['requests'].get('memory') or 'null'
@@ -2192,25 +2625,35 @@ def save_comparison_data_all_bases(task_name, all_recommendations_by_base, curre
                 curr_cpu_req = 'N/A'
                 curr_mem_lim = 'N/A'
                 curr_cpu_lim = 'N/A'
-            
+
             curr_req = f"{curr_mem_req} / {curr_cpu_req}"
             curr_lim = f"{curr_mem_lim} / {curr_cpu_lim}"
             prop_req = f"{proposed_mem} / {proposed_cpu}"
             prop_lim = f"{proposed_mem} / {proposed_cpu}"
-            
+
             html_content += f"""            <tr>
-                <td>{step_name_yaml}</td>
+                <td><strong>{step_name_yaml}</strong></td>
                 <td>{curr_req}</td>
                 <td>{prop_req}</td>
                 <td>{curr_lim}</td>
                 <td>{prop_lim}</td>
             </tr>
 """
-        
-        html_content += """        </tbody>
-    </table>
-"""
-    
+
+        html_content += "        </tbody>\n    </table>\n"
+
+        # Violators block (one per step, only when detailed_executions are available)
+        if detailed_executions:
+            for rec in recommendations:
+                if rec is None:
+                    continue
+                step_name      = rec['step_name']
+                step_disp      = normalize_step_name_for_compare(step_name)
+                mem_base       = rec.get('mem_base', 0)
+                cpu_base       = rec.get('cpu_base', 0)
+                viol           = _compute_violators_for_step(detailed_executions, step_name, mem_base, cpu_base)
+                html_content  += _html_violators_block(viol, mem_base, cpu_base, base_label, step_disp)
+
     html_content += """</body>
 </html>
 """
@@ -2227,6 +2670,9 @@ def save_comparison_data_all_bases(task_name, all_recommendations_by_base, curre
         'margin_pct': margin_pct,
         'recommendations_by_base': all_recommendations_by_base,
         'steps_without_observability_data': list(steps_without_observability_data or []),
+        'cluster_coverage_report': cluster_coverage_report or {},
+        'days_requested': days_requested or 0,
+        'heavy_tail_warnings': tail_warnings,
     }
     
     with open(json_path, 'w', encoding='utf-8') as f:
@@ -2563,13 +3009,16 @@ def collect_individual_pod_executions(task_name, steps, days=7, parallel_cluster
                     if debug:
                         print(f"DEBUG: Found {len(pods)} pods for step {step} in cluster {cluster_name}", file=sys.stderr)
                     
-                    # For each pod, get max memory and CPU usage during its lifetime
+                    # For each pod, get max memory, CPU, and disk I/O during its lifetime
                     for pod_name, namespace in pods:
                         # Query max memory for this pod over the time range
                         mem_query = f'max_over_time(container_memory_working_set_bytes{{container="{step_name}",pod="{pod_name}",namespace=~".*-tenant"}}[{range_str}])'
                         # Query max CPU for this pod over the time range
                         cpu_query = f'max_over_time(rate(container_cpu_usage_seconds_total{{container="{step_name}",pod="{pod_name}",namespace=~".*-tenant"}}[5m])[{range_str}:5m])'
-                        
+                        # Finding 4: disk I/O — peak read and write throughput (MB/s)
+                        io_read_query = f'max_over_time(rate(container_fs_reads_bytes_total{{container="{step_name}",pod="{pod_name}",namespace=~".*-tenant"}}[5m])[{range_str}:5m])'
+                        io_write_query = f'max_over_time(rate(container_fs_writes_bytes_total{{container="{step_name}",pod="{pod_name}",namespace=~".*-tenant"}}[5m])[{range_str}:5m])'
+
                         query_script = script_dir / 'query_prometheus_range.py'
                         if not query_script.exists():
                             continue
@@ -2591,22 +3040,46 @@ def collect_individual_pod_executions(task_name, steps, days=7, parallel_cluster
                             env=env,
                             timeout=60
                         )
-                        
+
+                        # Query disk I/O read max
+                        io_read_result = subprocess.run(
+                            [sys.executable, str(query_script), token, prom_host, io_read_query, str(start_time), str(end_time)],
+                            capture_output=True,
+                            text=True,
+                            env=env,
+                            timeout=60
+                        )
+
+                        # Query disk I/O write max
+                        io_write_result = subprocess.run(
+                            [sys.executable, str(query_script), token, prom_host, io_write_query, str(start_time), str(end_time)],
+                            capture_output=True,
+                            text=True,
+                            env=env,
+                            timeout=60
+                        )
+
                         if mem_result.returncode != 0 or cpu_result.returncode != 0:
                             continue
                         
                         try:
                             mem_data = json.loads(mem_result.stdout)
                             cpu_data = json.loads(cpu_result.stdout)
-                            
+                            io_read_data = json.loads(io_read_result.stdout) if io_read_result.returncode == 0 and io_read_result.stdout.strip() else {}
+                            io_write_data = json.loads(io_write_result.stdout) if io_write_result.returncode == 0 and io_write_result.stdout.strip() else {}
+
                             # Get max values and first timestamp
                             mem_max = 0
                             cpu_max = 0
+                            io_read_max_bytes_s = 0   # bytes/s
+                            io_write_max_bytes_s = 0  # bytes/s
                             first_timestamp = None
                             
                             mem_series = mem_data.get('data', {}).get('result', [])
                             cpu_series = cpu_data.get('data', {}).get('result', [])
-                            
+                            io_read_series = io_read_data.get('data', {}).get('result', [])
+                            io_write_series = io_write_data.get('data', {}).get('result', [])
+
                             # Extract max memory and first timestamp
                             if mem_series:
                                 for series in mem_series:
@@ -2633,7 +3106,23 @@ def collect_individual_pod_executions(task_name, steps, days=7, parallel_cluster
                                             cpu_val = float(val) if val else 0
                                             if cpu_val > cpu_max:
                                                 cpu_max = cpu_val
-                            
+
+                            # Extract max disk I/O read (bytes/s -> MB/s)
+                            for series in io_read_series:
+                                if series.get('metric', {}).get('pod') == pod_name:
+                                    for ts, val in series.get('values', []):
+                                        v = float(val) if val else 0
+                                        if v > io_read_max_bytes_s:
+                                            io_read_max_bytes_s = v
+
+                            # Extract max disk I/O write (bytes/s -> MB/s)
+                            for series in io_write_series:
+                                if series.get('metric', {}).get('pod') == pod_name:
+                                    for ts, val in series.get('values', []):
+                                        v = float(val) if val else 0
+                                        if v > io_write_max_bytes_s:
+                                            io_write_max_bytes_s = v
+
                             # If no data found, skip this pod
                             if mem_max == 0 and first_timestamp is None:
                                 continue
@@ -2643,7 +3132,11 @@ def collect_individual_pod_executions(task_name, steps, days=7, parallel_cluster
                             
                             # Convert memory from bytes to MB
                             mem_mb = mem_max / (1024 * 1024)
-                            
+
+                            # Convert I/O from bytes/s to MB/s
+                            io_read_mbps = round(io_read_max_bytes_s / (1024 * 1024), 3)
+                            io_write_mbps = round(io_write_max_bytes_s / (1024 * 1024), 3)
+
                             # Use first timestamp or current time as fallback
                             if first_timestamp:
                                 exec_timestamp = datetime.fromtimestamp(first_timestamp).strftime('%Y-%m-%d %H:%M:%S')
@@ -2670,6 +3163,8 @@ def collect_individual_pod_executions(task_name, steps, days=7, parallel_cluster
                                 'timestamp': exec_timestamp,
                                 'memory_mb': round(mem_mb, 2),
                                 'cpu_cores': round(cpu_max, 4),
+                                'io_read_mbps': io_read_mbps,
+                                'io_write_mbps': io_write_mbps,
                                 'mem_requests_k8s': mem_req_k8s,
                                 'cpu_requests_k8s': cpu_req_k8s,
                                 'mem_limits_k8s': mem_lim_k8s,
@@ -3619,6 +4114,36 @@ Examples:
             parallel_clusters=parallel_workers, debug=args.debug,
             current_resources=current_resources
         )
+
+        # Finding 2: compute and print cluster data coverage report
+        cluster_coverage_report = compute_cluster_coverage_report(detailed_executions, args.days)
+        if cluster_coverage_report:
+            print("\n" + "=" * 80, file=sys.stderr)
+            print("Cluster Data Coverage Report (oldest data point per cluster):", file=sys.stderr)
+            print("=" * 80, file=sys.stderr)
+            any_short = False
+            for cl in sorted(cluster_coverage_report):
+                info = cluster_coverage_report[cl]
+                ok = info['meets_requested']
+                mark = "✓" if ok else "⚠"
+                print(
+                    f"  {mark} {cl}: {info['days_covered']:.1f} days covered "
+                    f"(oldest: {info['oldest_date']}, pods: {info['pod_count']})",
+                    file=sys.stderr,
+                )
+                if not ok:
+                    any_short = True
+            if any_short:
+                print(
+                    f"\n  WARNING: Some clusters returned fewer than {args.days} days of data.",
+                    file=sys.stderr,
+                )
+                print(
+                    "  Statistics may under-represent rare heavy workloads on those clusters.",
+                    file=sys.stderr,
+                )
+            print("=" * 80, file=sys.stderr)
+
         csv_data = detailed_executions_to_csv(detailed_executions)
         if not csv_data or not csv_data.strip() or csv_data.count('\n') < 1:
             print("Error: No data from detailed collection (no pods or no metrics).", file=sys.stderr)
@@ -3647,6 +4172,7 @@ Examples:
     else:
         # Read from stdin (e.g. user ran wrapper and piped CSV)
         detailed_executions = None
+        cluster_coverage_report = {}
         if sys.stdin.isatty():
             print("Error: No input provided. Use --file or pipe CSV data.", file=sys.stderr)
             sys.exit(1)
@@ -3723,7 +4249,10 @@ Examples:
     analyzed_json_path = None
     if file_path_or_url and task_name and csv_data:
         analyzed_html_path, analyzed_json_path = save_analyzed_data(
-            task_name, csv_data, date_str, steps_without_observability_data=steps_missing_obs
+            task_name, csv_data, date_str,
+            steps_without_observability_data=steps_missing_obs,
+            cluster_coverage_report=cluster_coverage_report if args.file else None,
+            days_requested=args.days if args.file else None,
         )
         print(f"\nSaved analyzed data:", file=sys.stderr)
         print(f"  - {analyzed_html_path}", file=sys.stderr)
@@ -3735,7 +4264,10 @@ Examples:
     if file_path_or_url and task_name:
         comparison_html_path, comparison_json_path = save_comparison_data_all_bases(
             task_name, all_recommendations_by_base, current_resources, args.margin, date_str,
-            use_timestamp=analyzed_files_exist, steps_without_observability_data=steps_missing_obs
+            use_timestamp=analyzed_files_exist, steps_without_observability_data=steps_missing_obs,
+            cluster_coverage_report=cluster_coverage_report if args.file else None,
+            days_requested=args.days if args.file else None,
+            detailed_executions=detailed_executions if detailed_executions else None,
         )
         print(f"\nSaved comparison data (all base metrics, margin={args.margin}%):", file=sys.stderr)
         print(f"  - {comparison_html_path}", file=sys.stderr)
@@ -3764,10 +4296,6 @@ Examples:
         else:
             print("\n✗ Aggregate verification found mismatches (see above). Please report if this persists.", file=sys.stderr)
 
-    # Print analysis for default base (max) for display (skip HTML saving since we already saved it)
-    if all_recommendations_by_base.get('max'):
-        print_analysis(all_recommendations_by_base['max'], args.margin, 'max', current_resources, task_name, save_comparison_html=False)
-    
     print(f"\nPhase 1 (Analysis) completed. All base metrics (max, p95, p90, median) have been generated.", file=sys.stderr)
     if steps_missing_obs:
         print(
@@ -3775,7 +4303,10 @@ Examples:
             f"also steps_without_observability_data in saved JSON).",
             file=sys.stderr,
         )
-    print(f"Run Phase 2 (--update) with --file to view recommendations for a specific base metric.", file=sys.stderr)
+    if comparison_html_path:
+        print(f"\nReview the comparison report to choose your base metric (max / p95 / p90 / median):", file=sys.stderr)
+        print(f"  → {comparison_html_path}", file=sys.stderr)
+    print(f"\nRun Phase 2 (--update) with --file to apply recommendations for a specific base metric.", file=sys.stderr)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## feat(analyze_resource_limits): coverage reporting, disk I/O metrics, violators sub-tables

### Why

The fleet analysis tool was producing recommendations without surfacing
critical data-quality signals: it could not tell reviewers how much history
Prometheus actually returned, missed disk I/O as a resource dimension
(directly relevant after Zhiming Xiong's finding of ~130 MB/s saturation
in `fips-operator-check-step-action`), and gave no indication of which
tenants would exceed a proposed limit — making it hard to confidently
choose between MAX, P95, P90, and Median as a recommendation base.

### What

**Cluster data coverage (Finding 2)**
- Computes the oldest timestamp per cluster from collected pod executions
- Prints a per-cluster coverage table to stderr at end of Phase 1
- Injects a coverage banner into both comparison and analyzed-data HTML
  so readers know when a cluster returned fewer days than requested

**Disk I/O metrics (Finding 4)**
- Adds `container_fs_reads_bytes_total` and `container_fs_writes_bytes_total`
  PromQL queries per pod during data collection
- Stores `io_read_mbps` / `io_write_mbps` per execution
- Renders Peak Disk Read / Write (MB/s) columns in the detailed-step
  HTML and CSV; rows exceeding 50 MB/s are highlighted in amber

**Violators sub-tables in comparison HTML**
- For each base metric section (MAX / P95 / P90 / Median), a collapsible
  amber `<details>` block lists every namespace → application → component
  group whose observed peak exceeded that threshold
- Shows exact peak values and `+delta ⚠` annotations for memory and CPU
  independently — so a CPU-only or memory-only violation is correctly shown
- Implemented via two new helper functions:
  `_compute_violators_for_step` and `_html_violators_block`

**Quality / transparency banners in HTML**
- Heavy-tail warning: flags steps with Max/P95 memory ratio ≥ 3×
- Prometheus scrape interval advisory: makes the 15–30 s capture
  blind-spot explicit to report readers

**Phase 1 console cleanup**
- Removed the verbose `RESOURCE LIMIT RECOMMENDATIONS` and
  `RESOURCE LIMITS COMPARISON` console blocks from Phase 1 stdout
- Phase 1 now ends with a single pointer to the comparison HTML file;
  all detail lives in the report

### Test

```bash
./analyze_resource_limits.py \
  --file https://github.com/konflux-ci/build-definitions/blob/main/task/fbc-fips-check-oci-ta/0.1/fbc-fips-check-oci-ta.yaml \
  --analyze-again --margin 5 --days 15 --pll-clusters 4