### PR TITLE
fix(analyze_resource_limits): support Tekton v1beta1 resources field

### DIFF
--- a/tools/tasks-and-steps-resource-analyzer/analyze_resource_limits.py
+++ b/tools/tasks-and-steps-resource-analyzer/analyze_resource_limits.py
@@ -80,8 +80,9 @@ def extract_task_info(yaml_content):
     current_resources = {}
     
     # Get default resources from stepTemplate
+    # Support both Tekton v1 (computeResources) and v1beta1 (resources) field names
     step_template = yaml_content.get('spec', {}).get('stepTemplate', {})
-    default_resources = step_template.get('computeResources', {})
+    default_resources = step_template.get('computeResources') or step_template.get('resources', {})
     default_mem_req = default_resources.get('requests', {}).get('memory', '')
     default_cpu_req = default_resources.get('requests', {}).get('cpu', '')
     default_mem_lim = default_resources.get('limits', {}).get('memory', '')
@@ -94,7 +95,8 @@ def extract_task_info(yaml_content):
             steps.append(step_name)
             
             # Get current resources for this step (use defaults if not specified)
-            step_resources = step.get('computeResources', {})
+            # Support both Tekton v1 (computeResources) and v1beta1 (resources) field names
+            step_resources = step.get('computeResources') or step.get('resources', {})
             step_req = step_resources.get('requests', {})
             step_lim = step_resources.get('limits', {})
             
@@ -2714,6 +2716,7 @@ def save_comparison_data_all_bases(task_name, all_recommendations_by_base, curre
         'cluster_coverage_report': cluster_coverage_report or {},
         'days_requested': days_requested or 0,
         'heavy_tail_warnings': tail_warnings,
+        'current_resources': current_resources or {},
     }
     
     with open(json_path, 'w', encoding='utf-8') as f:


### PR DESCRIPTION
## Summary
- **Bug fix:** `extract_task_info()` only read `computeResources` (Tekton v1
  field name) and silently returned `null` for tasks using
  `apiVersion: tekton.dev/v1beta1`, which spells the same field as `resources`.
  As a result, the comparison HTML reports showed `null / null` for Current
  Requests and Current Limits columns even when the YAML had them defined
  (e.g. `build-helm-chart-oci-ta`).
- **Fix:** Use `step.get('computeResources') or step.get('resources', {})` for
  both the `stepTemplate` block and each individual step — tries Tekton v1 first,
  falls back to v1beta1 transparently.
- **Persistence fix:** `current_resources` is now saved into the comparison JSON
  so future in-place HTML regeneration scripts can recover the values without
  re-fetching the source YAML.
## Test plan
- [ ] Run against a `tekton.dev/v1beta1` task (e.g. `build-helm-chart-oci-ta`)
  and verify Current Requests / Current Limits show correct values (`256Mi / 50m`,
  `64Mi / 50m`) in the comparison HTML
- [ ] Run against a `tekton.dev/v1` task (e.g. `fbc-fips-check-oci-ta`) and
  verify existing behaviour is unchanged
- [ ] Confirm `current_resources` key is present in the generated comparison JSON