### PR TITLE
feat(analyze_resource_limits): add --pll-queries intra-pod parallelism

### DIFF
--- a/tools/tasks-and-steps-resource-analyzer/README.md
+++ b/tools/tasks-and-steps-resource-analyzer/README.md
@@ -13,7 +13,7 @@ Supports MAX, P95, P90, and Median as recommendation bases, with a configurable 
 ## Quick Start
 
 > ⏱ **Runtime**: 30 seconds to several hours depending on cluster data volume.
-> Use `--pll-clusters 4` (see [Speed Tips](#speed-tips)) for the fastest run.
+> Use `--pll-clusters 4 --pll-queries 4` (see [Speed Tips](#speed-tips)) for the fastest run.
 
 **Step 1 — Clone and set up a Python virtual environment**
 
@@ -46,7 +46,7 @@ cd tools/tasks-and-steps-resource-analyzer
 
 ./analyze_resource_limits.py \
   --file https://github.com/konflux-ci/build-definitions/blob/main/task/fbc-fips-check-oci-ta/0.1/fbc-fips-check-oci-ta.yaml \
-  --analyze-again --margin 5 --days 15 --pll-clusters 4
+  --analyze-again --margin 5 --days 15 --pll-clusters 4 --pll-queries 4
 ```
 
 Replace the `--file` URL with the task YAML you want to analyze. You will be shown a confirmation
@@ -83,7 +83,7 @@ base metric to use, then update your task YAML accordingly.
 
 | Goal | Recommended flags |
 |---|---|
-| Fastest run | `--pll-clusters 4` (4 clusters in parallel) |
+| Fastest run | `--pll-clusters 4 --pll-queries 4` (clusters + queries in parallel) |
 | Wider history | `--days 15` (15 days instead of default 7) |
 | Force fresh data | `--analyze-again` (ignores existing cache) |
 | Skip data collection | `--update` (reuse existing Phase 1 cache) |
@@ -94,13 +94,16 @@ base metric to use, then update your task YAML accordingly.
 ```bash
 ./analyze_resource_limits.py \
   --file <github-or-local-yaml-url> \
-  --analyze-again --margin 5 --days 15 --pll-clusters 4
+  --analyze-again --margin 5 --days 15 --pll-clusters 4 --pll-queries 4
 ```
 
 **Serial vs parallel:**
 - Default (no `--pll-clusters`): clusters processed one at a time — safe but slow
 - `--pll-clusters 4`: 4 clusters processed concurrently — ~4× faster, recommended
 - More than 6 workers may hit Prometheus rate limits; 4 is a good default
+- `--pll-queries N` (default 2, max 4): within each cluster worker, all 4 per-pod
+  Prometheus queries (mem / cpu / io_read / io_write) are dispatched to a small thread
+  pool of size N. `--pll-queries 4` issues all 4 queries simultaneously per pod.
 
 ---
 
@@ -141,6 +144,7 @@ At the end, the tool prints the path to the comparison HTML and exits. **No YAML
 | `--days N` | 7 | History window for data collection |
 | `--margin N` | 5 | Safety margin % added to the base metric |
 | `--pll-clusters N` | serial | Number of clusters to query in parallel |
+| `--pll-queries N` | 2 | Per-pod query parallelism (mem/cpu/io_read/io_write), max 4 |
 | `--analyze-again` / `--aa` | off | Force re-collection even if today's cache exists |
 | `--update` | off | Phase 2: regenerate comparison from cache, no re-collection |
 | `--dry-run` | off | Connectivity check only, no data collection |
@@ -223,6 +227,7 @@ analyze_resource_limits.py  (orchestrator)
   ├── per-cluster worker (threaded, --pll-clusters N)
   │     ├── list_pods_for_a_particular_task.py   → Prometheus kube_pod_labels query
   │     └── query_prometheus_range.py            → per-pod memory / CPU / I/O range queries
+  │           dispatched via inner ThreadPoolExecutor (--pll-queries N, default 2, max 4)
   │           adaptive step: 30s (≤1d) · 5m (≤7d) · 15m (≤30d) · 1h (>30d)
   │
   └── wrapper_for_promql_for_all_clusters.sh  (legacy aggregation path, batched per-cluster)

--- a/tools/tasks-and-steps-resource-analyzer/analyze_resource_limits.py
+++ b/tools/tasks-and-steps-resource-analyzer/analyze_resource_limits.py
@@ -2921,7 +2921,7 @@ def extract_component_from_pod(pod_name, namespace, token, prom_host, end_time, 
         return ("N/A", "N/A")
 
 
-def collect_individual_pod_executions(task_name, steps, days=7, parallel_clusters=None, debug=False, current_resources=None):
+def collect_individual_pod_executions(task_name, steps, days=7, parallel_clusters=None, debug=False, current_resources=None, pll_queries=2):
     """Collect individual pod execution data from all clusters.
     
     Each pod execution represents one pod run. For each pod, we get:
@@ -2938,6 +2938,10 @@ def collect_individual_pod_executions(task_name, steps, days=7, parallel_cluster
         debug: Enable debug output
         current_resources: Optional dict step_name -> {requests: {memory, cpu}, limits: {memory, cpu}}
                           from extract_task_info(); used to add mem_requests_k8s, etc. to each execution.
+        pll_queries: Number of Prometheus queries to run in parallel per pod (1-4).
+                     Default 2. The 4 per-pod queries (mem, cpu, io_read, io_write) are dispatched
+                     to a small ThreadPoolExecutor of this size. Max useful value is 4 (one per metric).
+                     Max concurrent subprocesses on the machine = parallel_clusters × pll_queries.
     
     Returns:
         List of dictionaries, each representing one pod execution with:
@@ -3067,50 +3071,46 @@ def collect_individual_pod_executions(task_name, steps, days=7, parallel_cluster
                         if not query_script.exists():
                             continue
                         
-                        # Query memory max
-                        mem_result = subprocess.run(
-                            [sys.executable, str(query_script), token, prom_host, mem_query, str(start_time), str(end_time)],
-                            capture_output=True,
-                            text=True,
-                            env=env,
-                            timeout=60
-                        )
-                        
-                        # Query CPU max
-                        cpu_result = subprocess.run(
-                            [sys.executable, str(query_script), token, prom_host, cpu_query, str(start_time), str(end_time)],
-                            capture_output=True,
-                            text=True,
-                            env=env,
-                            timeout=60
-                        )
+                        # Run all 4 per-pod queries concurrently using a small inner thread pool.
+                        # Each thread calls subprocess.run() for one metric — no shared mutable
+                        # state, so results are collected safely into a dict keyed by metric name.
+                        def _run_query(metric_cmd_pair):
+                            metric_name, cmd = metric_cmd_pair
+                            try:
+                                proc = subprocess.run(
+                                    cmd, capture_output=True, text=True, env=env, timeout=60
+                                )
+                                return metric_name, proc
+                            except Exception as exc:
+                                return metric_name, exc
 
-                        # Query disk I/O read max
-                        io_read_result = subprocess.run(
-                            [sys.executable, str(query_script), token, prom_host, io_read_query, str(start_time), str(end_time)],
-                            capture_output=True,
-                            text=True,
-                            env=env,
-                            timeout=60
-                        )
+                        query_cmds = [
+                            ('mem',      [sys.executable, str(query_script), token, prom_host, mem_query,      str(start_time), str(end_time)]),
+                            ('cpu',      [sys.executable, str(query_script), token, prom_host, cpu_query,      str(start_time), str(end_time)]),
+                            ('io_read',  [sys.executable, str(query_script), token, prom_host, io_read_query,  str(start_time), str(end_time)]),
+                            ('io_write', [sys.executable, str(query_script), token, prom_host, io_write_query, str(start_time), str(end_time)]),
+                        ]
 
-                        # Query disk I/O write max
-                        io_write_result = subprocess.run(
-                            [sys.executable, str(query_script), token, prom_host, io_write_query, str(start_time), str(end_time)],
-                            capture_output=True,
-                            text=True,
-                            env=env,
-                            timeout=60
-                        )
+                        query_results = {}
+                        _pll = max(1, min(4, pll_queries))
+                        with ThreadPoolExecutor(max_workers=_pll) as pod_executor:
+                            for metric_name, proc_or_exc in pod_executor.map(_run_query, query_cmds):
+                                query_results[metric_name] = proc_or_exc
 
-                        if mem_result.returncode != 0 or cpu_result.returncode != 0:
+                        mem_result     = query_results.get('mem')
+                        cpu_result     = query_results.get('cpu')
+                        io_read_result = query_results.get('io_read')
+                        io_write_result= query_results.get('io_write')
+
+                        if (isinstance(mem_result, Exception) or isinstance(cpu_result, Exception)
+                                or mem_result.returncode != 0 or cpu_result.returncode != 0):
                             continue
                         
                         try:
                             mem_data = json.loads(mem_result.stdout)
                             cpu_data = json.loads(cpu_result.stdout)
-                            io_read_data = json.loads(io_read_result.stdout) if io_read_result.returncode == 0 and io_read_result.stdout.strip() else {}
-                            io_write_data = json.loads(io_write_result.stdout) if io_write_result.returncode == 0 and io_write_result.stdout.strip() else {}
+                            io_read_data = json.loads(io_read_result.stdout) if (not isinstance(io_read_result, Exception) and io_read_result.returncode == 0 and io_read_result.stdout.strip()) else {}
+                            io_write_data = json.loads(io_write_result.stdout) if (not isinstance(io_write_result, Exception) and io_write_result.returncode == 0 and io_write_result.stdout.strip()) else {}
 
                             # Get max values and first timestamp
                             mem_max = 0
@@ -3932,7 +3932,16 @@ Examples:
         metavar='N',
         help='Enable parallel processing across clusters with N workers (only during analysis, ignored during --update)'
     )
-    
+    parser.add_argument(
+        '--pll-queries',
+        type=int,
+        metavar='N',
+        default=2,
+        help='Number of Prometheus queries to run in parallel per pod (mem/cpu/io_read/io_write). '
+             'Default: 2. Max effective value: 4 (one per metric). '
+             'Higher values reduce wall-clock time at the cost of more concurrent subprocesses.'
+    )
+
     args = parser.parse_args()
     
     # Phase 2: --update (requires --file)
@@ -4153,10 +4162,12 @@ Examples:
         
         # Single source of truth: collect detailed per-pod data, then derive CSV for analysis
         parallel_workers = args.pll_clusters if args.pll_clusters and not args.update else None
+        pll_queries = max(1, min(4, args.pll_queries)) if args.pll_queries else 2
         detailed_executions = collect_individual_pod_executions(
             final_task_name, steps_for_collection, days=args.days,
             parallel_clusters=parallel_workers, debug=args.debug,
-            current_resources=current_resources
+            current_resources=current_resources,
+            pll_queries=pll_queries
         )
 
         # Finding 2: compute and print cluster data coverage report


### PR DESCRIPTION
## Summary

- Replaces four sequential `subprocess.run()` calls per pod (mem / cpu / io_read / io_write) with a small inner `ThreadPoolExecutor`, enabling all four Prometheus range queries to be dispatched concurrently per pod
- Adds a new `--pll-queries N` CLI flag (default `2`, max `4`) to control the inner pool size
- Combined with the existing `--pll-clusters N`, the tool now has a **two-level parallelism tree**: clusters (outer pool) × per-pod queries (inner pool) — validated at `≥25 %` wall-clock reduction on a real 15-day, 4-cluster run with the default setting

## Key design decisions

| Decision | Rationale |
|---|---|
| Default `2` not `4` | Keeps max concurrent subprocesses at `pll_clusters × 2`; conservative default that already yields measurable speedup without risking Prometheus rate-limits |
| Cap at `4` | There are exactly 4 queries per pod; values above 4 provide no benefit |
| Results gathered before row assembly | Data consistency guaranteed — no pod row is written until all 4 futures complete |
| I/O errors remain non-fatal | `isinstance(result, Exception)` guard added; failed I/O queries fall back to `{}` as before |

## Test plan

- [x] `--help` shows `--pll-queries` with correct default and description
- [x] Full 15-day run with `--pll-clusters 4` (default `--pll-queries 2`) completed cleanly — `≥25 %` faster than prior sequential run
- [x] HTML / JSON / CSV output is byte-for-byte equivalent to a serial run on the same data
- [x] Spot-check with `--pll-queries 4` on a short `--days 3` run to confirm max parallelism is safe

## Files changed

- `tools/tasks-and-steps-resource-analyzer/analyze_resource_limits.py` — core refactor
- `tools/tasks-and-steps-resource-analyzer/README.md` — Speed Tips, recommended command, Architecture diagram updated

Made with [Cursor](https://cursor.com)