### PR TITLE
docs(analyze_resource_limits): note RHOBS as future data source

### DIFF
--- a/tools/tasks-and-steps-resource-analyzer/README.md
+++ b/tools/tasks-and-steps-resource-analyzer/README.md
@@ -267,6 +267,32 @@ present in your `~/.kube/config`.
 
 ---
 
+## Future Enhancement: Long-term Metrics via RHOBS
+
+The tool is currently bounded by each cluster's local Prometheus retention (typically 4-11 days).
+A longer-term data source exists but is not yet connected:
+
+**RHOBS (Red Hat Observability Service)** retains metrics for up to a year and is queryable via
+AppSRE Grafana (datasource: `rhtap-observatorium-stage` / `rhtap-observatorium-production`).
+
+As noted by Faisal Al-Rayes in
+[KONFLUX-13351](https://redhat.atlassian.net/browse/KONFLUX-13351?focusedCommentId=16869177):
+
+- Raw per-pod metrics (`container_memory_working_set_bytes`, `container_cpu_usage_seconds_total`)
+  are **not** forwarded to RHOBS — the per-pod label combination is too high in cardinality for
+  the shared Prometheus instance.
+- An **aggregated form** (per `container/tektonstepname` per namespace, not per unique pod) **is**
+  forwarded and retained long-term.
+- Extending the aggregation to cover `*-tenant` namespaces is potentially feasible, but requires a
+  cardinality and ephemeral-namespace review before enabling.
+
+**Potential future work:** if `*-tenant` namespaces are added to the RHOBS aggregation rules, the
+tool could query RHOBS as a long-term supplement — providing step-level trend data well beyond
+Prometheus retention. Per-pod execution detail (needed for distribution analysis) would still
+require local Prometheus.
+
+---
+
 ## Contributing / Feedback
 
 The tool has been used across Konflux to right-size resources for tasks including `buildah`,


### PR DESCRIPTION
## Summary

- Adds a new **"Future Enhancement: Long-term Metrics via RHOBS"** section to `README.md`
- Documents findings from [KONFLUX-13351](https://redhat.atlassian.net/browse/KONFLUX-13351?focusedCommentId=16869177) (Faisal Al-Rayes) explaining why raw per-pod metrics are not in RHOBS and what is available
- Notes the potential path forward (extending `*-tenant` namespace aggregation) for future implementors
- No code or behaviour changes — `README.md` only

## Background

The tool is bounded by local Prometheus retention (4–11 days per cluster). After investigating Splunk, KubeArchive, and Thanos as alternatives (all ruled out), Faisal Al-Rayes identified RHOBS as a viable long-term store for *aggregated* step-level metrics, retained up to a year. This PR captures that knowledge so it is not lost.

## Test plan

- [x] `README.md` renders correctly (new section appears between Known Limitations and Contributing)
- [x] All Jira links are valid and point to the correct comment
- [x] No code changes — no functional testing needed

Signed-off-by: Subrata Modak <smodak@redhat.com>
Assisted-by: CursorAI

Made with [Cursor](https://cursor.com)

[KONFLUX-13351]: https://redhat.atlassian.net/browse/KONFLUX-13351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ