### PR TITLE
Add timestamp to tarball filenames to prevent overwrites

### DIFF
--- a/tools/oomkill-and-crashloopbackoff-detector/oom_logs_and_desc_bundle_generator
+++ b/tools/oomkill-and-crashloopbackoff-detector/oom_logs_and_desc_bundle_generator
@@ -255,9 +255,9 @@ Behavior:
   1. Scans all date-wise CSV files in OUTPUT_DIR (oom_results_<DD>-<Mon>-<YYYY>_*.csv).
   2. For the given POD, reports how many OOMKilled and CrashLoopBackOff instances were
      detected and on which days.
-  3. Creates one tarball per (type, date), with pod name in the filename, under output/tarballs/, e.g.:
-     output/tarballs/OOMKilled-image-controller-image-pruner-cronjob-instance-28th-Jan-2026.tgz
-     output/tarballs/CrashLoopBackOff-image-controller-image-pruner-cronjob-instance-29th-Jan-2026.tgz
+  3. Creates one tarball per (type, date, time), with pod name in the filename, under output/tarballs/, e.g.:
+     output/tarballs/OOMKilled-image-controller-image-pruner-cronjob-instance-28th-Jan-2026-09-15.tgz
+     output/tarballs/CrashLoopBackOff-image-controller-image-pruner-cronjob-instance-29th-Jan-2026-14-30.tgz
      Find all tarballs for a pod: ls output/tarballs/*<pod-name>*.tgz
      Each tarball contains logs and descriptions for that pod on that date.
 
@@ -483,7 +483,9 @@ for key in "${!FILES_BY_KEY[@]}"; do
         date_label="$date_key"
     fi
     # Include pod name in tarball filename so you can find with: ls tarballs/*image-controller-image-pruner-cronjob*.tgz
-    tarball_name="${type}-${POD_SANITIZED}-instance-${date_label}.tgz"
+    # Add timestamp (HH-MM) to prevent overwrites when tool runs multiple times per day
+    timestamp=$(date +"%H-%M")
+    tarball_name="${type}-${POD_SANITIZED}-instance-${date_label}-${timestamp}.tgz"
     tarball_path="${TARBALL_DIR}/${tarball_name}"
     tmpdir="${TMP_BASE}/${type}-${date_key}"
     mkdir -p "$tmpdir"


### PR DESCRIPTION
## Summary
When the OOM detection tool runs multiple times per day (e.g., 8 times daily in Jenkins), tarballs with the same pod name and date would overwrite each other, losing evidence from earlier runs.

This PR adds HH-MM timestamp suffixes to tarball filenames to ensure each Jenkins run preserves its own artifacts.

## Changes
- Add HH-MM timestamp suffix to tarball filenames in `oom_logs_and_desc_bundle_generator`
- Updated tarball format: `{Type}-{pod}-instance-{date}-{HH-MM}.tgz`
- Example: `OOMKilled-operator-bundle-on-push-instance-6th-May-2026-14-35.tgz`
- Updated documentation to reflect new naming format

## Impact
- Ensures complete evidence collection for all OOM/CrashLoopBackOff incidents throughout the day
- Backward compatible: `oom_jira_lib.py` regex patterns support both old (no timestamp) and new (with timestamp) formats
- No changes needed to `oc_get_ooms.py` as it invokes the bundle generator as a subprocess

## Test Plan
- [ ] Verify tarball generation includes timestamp in filename
- [ ] Verify multiple runs on same day create separate tarballs
- [ ] Verify Jira ticket creation correctly parses both old and new tarball formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)