### PR TITLE
fix(oc_get_ooms): stop ImagePullBackOff being a CrashLoop false-positive

### DIFF
--- a/tools/oomkill-and-crashloopbackoff-detector/oc_get_ooms.py
+++ b/tools/oomkill-and-crashloopbackoff-detector/oc_get_ooms.py
@@ -1153,7 +1153,12 @@ def namespace_worker_oc(
             oom_events.append(event_data)
         elif "crashloop" in reason_lower:
             crash_events.append(event_data)
-        elif "backoff" in reason_lower:
+        elif reason_lower == "backoff":
+            # Match only the exact Kubernetes "BackOff" restart reason (container
+            # crash exponential back-off). The previous substring match
+            # "backoff" in reason_lower also caught ImagePullBackOff and
+            # ErrImageBackOff, which are image-pull failures — not crash loops —
+            # causing false-positive CrashLoopBackOff reports (KONFLUX-13422).
             backoff_events.append(event_data)
 
     # Fetch pods once for both OOM/Crash detection and for application/component labels (incl. event-only pods)


### PR DESCRIPTION
## Problem

`oc_get_ooms.py` was misclassifying `ImagePullBackOff` (and `ErrImageBackOff`) events as CrashLoopBackOff incidents. The root cause was an overly broad substring check:

```python
elif "backoff" in reason_lower:
    backoff_events.append(event_data)
```

The string `"backoff"` appears in both:
- `BackOff` – the Kubernetes restart reason for container crash-loop exponential back-off ✅ (correct match)
- `ImagePullBackOff` / `ErrImageBackOff` – image-pull failures ❌ (false positive)

This was reported by Faisal Al-Rayes in KONFLUX-13422 (comment 16964715), where it was confirmed that pods with `ImagePullBackOff` were surfacing in the tool's CrashLoopBackOff output.

## Fix

Change the condition to an exact equality check:

```python
elif reason_lower == "backoff":
```

Only the bare Kubernetes `BackOff` restart reason (all-lowercase: `"backoff"`) will now match, eliminating the false positives while preserving all true CrashLoopBackOff detections.

## Testing

- Python syntax check: `python3 -m py_compile oc_get_ooms.py` — OK
- `flake8 --select=E9,F4,F8` on the changed file — no new violations introduced

## References

- Jira: [KONFLUX-13422](https://redhat.atlassian.net/browse/KONFLUX-13422) (comment 16964715 by Faisal Al-Rayes)

Made with [Cursor](https://cursor.com)

[KONFLUX-13422]: https://redhat.atlassian.net/browse/KONFLUX-13422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ