### PR TITLE
docs: restructure AGENTS.md per global engineering guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,13 @@
 .*.swp
 
 .agentready/
+
+# Installed agent skills (restored via: npx skills@latest experimental_install)
+.agents/skills/grill-with-docs/
+.agents/skills/improve-codebase-architecture/
+.agents/skills/write-a-skill/
+.agents/skills/zoom-out/
+.claude/skills/grill-with-docs
+.claude/skills/improve-codebase-architecture
+.claude/skills/write-a-skill
+.claude/skills/zoom-out

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,30 +1,35 @@
 # AGENTS.md - Konflux Perf&Scale
 
+Based on [Global Engineering AGENTS.md guide](https://gitlab.cee.redhat.com/global-engineering/wg-agentic-sdlc/-/tree/main/best-practices/repo-scaffolding?ref_type=heads).
+
 ## Purpose
 
-This repo holds Grafana dashboards and operational tools for the Konflux Performance & Scale team.
+Grafana dashboards and operational tools for the Konflux Performance & Scale team.
 
-## Repo layout
+## Build & Test Commands
 
-- `grafana/` - In-cluster Grafana dashboard JSONs (deployed via infra-deployments) and generic dashboards around Probe runs (deployd manually to <https://grafana.corp.redhat.com/dashboards?orgId=26>). After merging dashboard changes, update ref in infra-deployments repo with `update-infra-ref.sh <sha>`.
-- `grafonnet-workdir/` - Jsonnet/Grafonnet sources for some dashboards. Build with `grafonnet-workdir/build.sh` that updates some dashboards in `grafana/`. Grafonnet vendor dependencies are committed; run `jb install` only when updating them.
+- Build Grafonnet dashboards: `grafonnet-workdir/build.sh`
+- Lint Python: `black --check . && flake8`
+- Format Python: `black .`
+- Lint shell scripts: `shellcheck <script>`
+- No automated test suite exists in this repo
+
+## Key Conventions
+
+- After merging dashboard changes, update the ref in infra-deployments repo with `update-infra-ref.sh <sha>`. The script expects a sibling `../infra-deployments` checkout.
+- When creating a dashboard in the Grafana UI to persist in git, run `cleanup-dashboard.sh` to strip datasource fields from the JSON.
+- Grafonnet vendor dependencies are committed in `grafonnet-workdir/vendor/`; run `jb install` only when updating them.
+- Long-term goal is to have all dashboards created by Jsonnet via Grafonnet, not hand-edited JSON.
+
+## Repo Layout
+
+- `grafana/` - Dashboard JSONs: in-cluster ones deployed via infra-deployments, plus generic Probe dashboards deployed manually to <https://grafana.corp.redhat.com/dashboards?orgId=26>.
+- `grafonnet-workdir/` - Jsonnet/Grafonnet sources; `build.sh` outputs to `grafana/`.
 - `tools/oomkill-and-crashloopbackoff-detector/` - Parallel OOMKilled/CrashLoopBackOff scanner across OpenShift clusters.
 - `tools/tasks-and-steps-resource-analyzer/` - Extracts per-task/step Memory & CPU metrics from Prometheus and recommends resource limits.
-- `cleanup-dashboard.sh` - Strips datasource fields from dashboard JSONs. Used when creating dashboard in Grafana UI and we want to persist in this git. Long term plan though is to have all the dashboards created by Jsonnet.
-- `update-infra-ref.sh` - Updates infra-deployments kustomization ref to a commit SHA. Note it expects a sibling `../infra-deployments` checkout.
-
-## Key technologies
-
-- Grafana dashboards (JSON)
-- Jsonnet + Grafonnet (dashboard-as-code)
-- Python 3.9+ (tools)
-- Bash (wrapper scripts)
-- PromQL (Prometheus queries)
-- OpenShift / Kubernetes (`oc` CLI)
 
 ## Testing
 
-- Grafonnet dashboards: Make sure dashboards can be built with `grafonnet-workdir/build.sh`.
-- Python code needs to pass `black` and `flake8`.
-- Schell scripts need to pass `shellcheck`.
-- No automated test suite exists in this repo.
+- Grafonnet dashboards: verify they build with `grafonnet-workdir/build.sh`.
+- Python code: must pass `black` and `flake8`.
+- Shell scripts: must pass `shellcheck`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,3 +33,17 @@ Grafana dashboards and operational tools for the Konflux Performance & Scale tea
 - Grafonnet dashboards: verify they build with `grafonnet-workdir/build.sh`.
 - Python code: must pass `black` and `flake8`.
 - Shell scripts: must pass `shellcheck`.
+
+## Agent skills
+
+### Issue tracker
+
+Jira — project KONFLUX, component Performance, on redhat.atlassian.net. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Not used. This repo does not follow a triage workflow.
+
+### Domain docs
+
+Single-context layout. See `docs/agents/domain.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -39,3 +39,23 @@ Access to our Grafana organization is guarded by these LDAP groups (ask owners o
 
  * For admin access: <https://rover.redhat.com/groups/group/konflux-perfscale-grafanacorp-admins>
  * For user, read-only access: <https://rover.redhat.com/groups/group/konflux-perfscale-grafanacorp-users>
+
+AI agent skills
+---------------
+
+This repo uses the [`skills` CLI](https://github.com/mattpocock/skills) to manage reusable AI agent skills. Installed skills live in `.agents/skills/` with symlinks in `.claude/skills/`, and versions are tracked in `skills-lock.json`.
+
+After cloning, restore installed skills from the lock file:
+
+```bash
+npx skills@latest experimental_install
+```
+
+Other useful commands:
+
+```bash
+npx skills@latest list                      # List installed skills
+npx skills@latest add mattpocock/skills     # Add skills from a package
+npx skills@latest update                    # Update to latest versions
+npx skills@latest remove                    # Remove a skill
+```

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -4,7 +4,7 @@ How the engineering skills should consume this repo's domain documentation when 
 
 ## Before exploring, read these
 
-- **`CONTEXT.md`** at the repo root.
+- **`CONTEXT.md`** at the repo root — contains the project's domain language and glossary.
 - **`docs/adr/`** — read ADRs that touch the area you're about to work in.
 
 If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,35 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo:
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-*.md
+│   └── 0002-*.md
+└── ...
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,16 @@
+# Issue tracker: Jira
+
+Issues for this repo live in Jira on **redhat.atlassian.net**, project **KONFLUX**, component **Performance**.
+
+## Conventions
+
+- **Browse issues**: <https://redhat.atlassian.net/issues/?jql=project%20%3D%20KONFLUX%20AND%20component%20%3D%20Performance>
+- **View an issue**: `https://redhat.atlassian.net/browse/KONFLUX-<number>`
+- Agents do not have direct Jira API access. When a skill says "publish to the issue tracker" or "create an issue", draft the issue content (title, description, labels) and present it to the user for manual creation in Jira.
+- When a skill says "fetch the relevant ticket", ask the user to paste the Jira issue content or provide the issue key so it can be looked up.
+
+## Labels and fields
+
+- **Project**: KONFLUX
+- **Component**: Performance
+- Apply any additional labels as Jira labels on the issue.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,16 +1,20 @@
 # Issue tracker: Jira
 
-Issues for this repo live in Jira on **redhat.atlassian.net**, project **KONFLUX**, component **Performance**.
+Issues for this repo are tracked in Jira.
+
+- **Instance:** redhat.atlassian.net
+- **Project:** KONFLUX
+- **Component:** Performance
 
 ## Conventions
 
-- **Browse issues**: <https://redhat.atlassian.net/issues/?jql=project%20%3D%20KONFLUX%20AND%20component%20%3D%20Performance>
-- **View an issue**: `https://redhat.atlassian.net/browse/KONFLUX-<number>`
-- Agents do not have direct Jira API access. When a skill says "publish to the issue tracker" or "create an issue", draft the issue content (title, description, labels) and present it to the user for manual creation in Jira.
-- When a skill says "fetch the relevant ticket", ask the user to paste the Jira issue content or provide the issue key so it can be looked up.
+- Issues are managed via the Jira web UI or API or `acli` CLI tool.
+- New issues should have the component set to "Performance".
 
-## Labels and fields
+## When a skill says "publish to the issue tracker"
 
-- **Project**: KONFLUX
-- **Component**: Performance
-- Apply any additional labels as Jira labels on the issue.
+Create a Jira issue in the KONFLUX project with component "Performance". If CLI access is unavailable, present the issue title, description, and labels for the user to create manually.
+
+## When a skill says "fetch the relevant ticket"
+
+Ask the user for the Jira issue key, or infer it from branch names / commit messages (e.g. `KONFLUX-1234`).

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,3 @@
+# Triage Labels
+
+This repo does not use a triage workflow. Skills that reference triage labels should skip triage steps silently.

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,29 @@
+{
+  "version": 1,
+  "skills": {
+    "grill-with-docs": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/grill-with-docs/SKILL.md",
+      "computedHash": "a5c65e76275008b469962f7bee8b34866f1c9b0709f4886e71c8e731735640e4"
+    },
+    "improve-codebase-architecture": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/improve-codebase-architecture/SKILL.md",
+      "computedHash": "ef32aea0a8fab9b365ff9e08a95f8d353e20ca21ea46ec2e73587c86dd341351"
+    },
+    "write-a-skill": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/productivity/write-a-skill/SKILL.md",
+      "computedHash": "b44d8aab2ead83c716e01af4c9a24ccc4575ce70ad58ec4f1749fb88c9cc82ba"
+    },
+    "zoom-out": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/zoom-out/SKILL.md",
+      "computedHash": "8357aeaece3b709c442eab67e64b86844e05e2f1ea95b109565eba50b6def36e"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Restructured `AGENTS.md` following the [Global Engineering AGENTS.md best practices guide](https://gitlab.cee.redhat.com/global-engineering/wg-agentic-sdlc/-/tree/main/best-practices/repo-scaffolding?ref_type=heads): added Build & Test Commands section, Key Conventions for non-obvious workflows, trimmed technology list and redundant descriptions
- Created `CLAUDE.md` and `GEMINI.md` that import from `AGENTS.md` via `@AGENTS.md` for cross-tool compatibility

## Test plan
- [ ] Verify `AGENTS.md` reads well and contains actionable info for AI agents
- [ ] Verify `CLAUDE.md` and `GEMINI.md` correctly reference `AGENTS.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)