### PR TITLE
fix: prevent namespace misattribution in OOM/CrashLoop detection

### DIFF
--- a/tools/oomkill-and-crashloopbackoff-detector/oc_get_ooms.py
+++ b/tools/oomkill-and-crashloopbackoff-detector/oc_get_ooms.py
@@ -1180,7 +1180,12 @@ def namespace_worker_oc(
     for ev in all_events:
         reason = ev.get("reason", "")
         reason_lower = reason.lower()
-        pod = ev.get("involvedObject", {}).get("name")
+        involved = ev.get("involvedObject", {})
+        # Only process Pod events — ignore Node, DaemonSet, Deployment, etc.
+        # to prevent namespace misattribution (e.g. KONFLUX-14702).
+        if involved.get("kind") != "Pod":
+            continue
+        pod = involved.get("name")
         ts = ev.get("eventTime") or ev.get("lastTimestamp") or ev.get("firstTimestamp")
 
         if not pod or not ts:
@@ -1302,6 +1307,18 @@ def namespace_worker_oc(
         pod_map[p]["sources"].add("oc_get_pods")
         pod_map[p]["application"] = e.get("application", "") or pod_map[p].get("application", "")
         pod_map[p]["component"] = e.get("component", "") or pod_map[p].get("component", "")
+
+    # Drop event-only pods that don't exist in the pod listing — they indicate
+    # stale events or cross-namespace references that would cause namespace
+    # misattribution in downstream reports (e.g. KONFLUX-14702).
+    actual_pod_names = set(labels_map.keys())
+    if pod_map and actual_pod_names:
+        event_only = [
+            p for p, info in pod_map.items()
+            if info.get("sources", set()) == {"events"} and p not in actual_pod_names
+        ]
+        for p in event_only:
+            del pod_map[p]
 
     if pod_map:
         out_ns: dict[str, dict[str, Any]] = {}

--- a/tools/oomkill-and-crashloopbackoff-detector/oc_get_ooms.py
+++ b/tools/oomkill-and-crashloopbackoff-detector/oc_get_ooms.py
@@ -1314,7 +1314,8 @@ def namespace_worker_oc(
     actual_pod_names = set(labels_map.keys())
     if pod_map and actual_pod_names:
         event_only = [
-            p for p, info in pod_map.items()
+            p
+            for p, info in pod_map.items()
             if info.get("sources", set()) == {"events"} and p not in actual_pod_names
         ]
         for p in event_only:

--- a/tools/oomkill-and-crashloopbackoff-detector/test_namespace_misattribution.py
+++ b/tools/oomkill-and-crashloopbackoff-detector/test_namespace_misattribution.py
@@ -6,6 +6,7 @@ Verifies that namespace_worker_oc() correctly:
 1. Filters events by involvedObject.kind == "Pod"
 2. Drops event-only pods that don't exist in the namespace's pod listing
 """
+
 import sys
 from pathlib import Path
 from unittest.mock import patch, MagicMock
@@ -63,8 +64,10 @@ def test_non_pod_events_are_ignored(mock_crash, mock_oom, mock_pods, mock_events
     mock_pods.return_value = [make_pod_item("managed-upgrade-operator-xyz")]
 
     result = namespace_worker_oc(
-        "ctx", "openshift-managed-upgrade-operator",
-        retries=1, oc_timeout_seconds=10,
+        "ctx",
+        "openshift-managed-upgrade-operator",
+        retries=1,
+        oc_timeout_seconds=10,
     )
 
     assert result is not None, "Should find the Pod event"

--- a/tools/oomkill-and-crashloopbackoff-detector/test_namespace_misattribution.py
+++ b/tools/oomkill-and-crashloopbackoff-detector/test_namespace_misattribution.py
@@ -9,7 +9,7 @@ Verifies that namespace_worker_oc() correctly:
 
 import sys
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).parent))
 

--- a/tools/oomkill-and-crashloopbackoff-detector/test_namespace_misattribution.py
+++ b/tools/oomkill-and-crashloopbackoff-detector/test_namespace_misattribution.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""
+Test cases for namespace misattribution fix (KONFLUX-14702).
+
+Verifies that namespace_worker_oc() correctly:
+1. Filters events by involvedObject.kind == "Pod"
+2. Drops event-only pods that don't exist in the namespace's pod listing
+"""
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from oc_get_ooms import namespace_worker_oc
+
+
+def make_event(reason: str, pod_name: str, kind: str = "Pod", timestamp: str = "2026-06-20T12:00:00Z"):
+    return {
+        "reason": reason,
+        "involvedObject": {"kind": kind, "name": pod_name, "namespace": "test-ns"},
+        "eventTime": timestamp,
+        "lastTimestamp": timestamp,
+    }
+
+
+def make_pod_item(name: str, labels=None):
+    return {
+        "metadata": {"name": name, "labels": labels or {}},
+        "status": {"containerStatuses": [{"name": "main", "state": {"running": {}}, "lastState": {}, "restartCount": 0}]},
+    }
+
+
+@patch("oc_get_ooms.get_all_events_oc")
+@patch("oc_get_ooms.get_pods_items")
+@patch("oc_get_ooms.oomkilled_via_pods_oc", return_value=[])
+@patch("oc_get_ooms.crashloop_via_pods_oc", return_value=[])
+def test_non_pod_events_are_ignored(mock_crash, mock_oom, mock_pods, mock_events):
+    """Events with involvedObject.kind != 'Pod' must be ignored."""
+    mock_events.return_value = [
+        make_event("BackOff", "splunkforwarder-ds-abc12", kind="DaemonSet"),
+        make_event("OOMKilling", "some-node", kind="Node"),
+        make_event("BackOff", "managed-upgrade-operator-xyz", kind="Pod"),
+    ]
+    mock_pods.return_value = [make_pod_item("managed-upgrade-operator-xyz")]
+
+    result = namespace_worker_oc("ctx", "openshift-managed-upgrade-operator", retries=1, oc_timeout_seconds=10)
+
+    assert result is not None, "Should find the Pod event"
+    assert "managed-upgrade-operator-xyz" in result, "Pod event should be included"
+    assert "splunkforwarder-ds-abc12" not in result, "DaemonSet event must be excluded"
+    assert "some-node" not in result, "Node event must be excluded"
+    print("PASS: Non-Pod events are correctly ignored")
+
+
+@patch("oc_get_ooms.get_all_events_oc")
+@patch("oc_get_ooms.get_pods_items")
+@patch("oc_get_ooms.oomkilled_via_pods_oc", return_value=[])
+@patch("oc_get_ooms.crashloop_via_pods_oc", return_value=[])
+def test_event_only_pods_not_in_listing_are_dropped(mock_crash, mock_oom, mock_pods, mock_events):
+    """Pods found only via events but missing from pod listing must be dropped."""
+    mock_events.return_value = [
+        make_event("BackOff", "ghost-pod-from-stale-event", kind="Pod"),
+        make_event("BackOff", "real-pod-abc12", kind="Pod"),
+    ]
+    mock_pods.return_value = [make_pod_item("real-pod-abc12")]
+
+    result = namespace_worker_oc("ctx", "test-ns", retries=1, oc_timeout_seconds=10)
+
+    assert result is not None
+    assert "real-pod-abc12" in result, "Pod that exists in listing should be kept"
+    assert "ghost-pod-from-stale-event" not in result, "Event-only pod not in listing must be dropped"
+    print("PASS: Event-only pods not in listing are correctly dropped")
+
+
+@patch("oc_get_ooms.get_all_events_oc")
+@patch("oc_get_ooms.get_pods_items")
+@patch("oc_get_ooms.oomkilled_via_pods_oc")
+@patch("oc_get_ooms.crashloop_via_pods_oc", return_value=[])
+def test_pod_status_detected_pods_are_kept(mock_crash, mock_oom, mock_pods, mock_events):
+    """Pods found via pod status (oc_get_pods) should always be kept."""
+    mock_events.return_value = []
+    mock_pods.return_value = [make_pod_item("crash-pod-xyz")]
+    mock_oom.return_value = [{"pod": "crash-pod-xyz", "timestamp": "2026-06-20T12:00:00Z", "application": "", "component": ""}]
+
+    result = namespace_worker_oc("ctx", "test-ns", retries=1, oc_timeout_seconds=10)
+
+    assert result is not None
+    assert "crash-pod-xyz" in result, "Pod detected via pod status should be kept"
+    assert result["crash-pod-xyz"]["oom_timestamps"], "Should have OOM timestamps"
+    print("PASS: Pod-status-detected pods are correctly kept")
+
+
+@patch("oc_get_ooms.get_all_events_oc")
+@patch("oc_get_ooms.get_pods_items")
+@patch("oc_get_ooms.oomkilled_via_pods_oc", return_value=[])
+@patch("oc_get_ooms.crashloop_via_pods_oc", return_value=[])
+def test_no_false_negatives_for_real_event_pods(mock_crash, mock_oom, mock_pods, mock_events):
+    """Pods found via events AND present in pod listing should be kept."""
+    mock_events.return_value = [
+        make_event("BackOff", "real-crashing-pod-abc12", kind="Pod"),
+    ]
+    mock_pods.return_value = [make_pod_item("real-crashing-pod-abc12")]
+
+    result = namespace_worker_oc("ctx", "test-ns", retries=1, oc_timeout_seconds=10)
+
+    assert result is not None
+    assert "real-crashing-pod-abc12" in result, "Event pod present in listing should be kept"
+    print("PASS: Real event pods in listing are correctly kept")
+
+
+if __name__ == "__main__":
+    test_non_pod_events_are_ignored()
+    test_event_only_pods_not_in_listing_are_dropped()
+    test_pod_status_detected_pods_are_kept()
+    test_no_false_negatives_for_real_event_pods()
+    print("\nAll namespace misattribution tests passed!")

--- a/tools/oomkill-and-crashloopbackoff-detector/test_namespace_misattribution.py
+++ b/tools/oomkill-and-crashloopbackoff-detector/test_namespace_misattribution.py
@@ -15,10 +15,19 @@ sys.path.insert(0, str(Path(__file__).parent))
 from oc_get_ooms import namespace_worker_oc
 
 
-def make_event(reason: str, pod_name: str, kind: str = "Pod", timestamp: str = "2026-06-20T12:00:00Z"):
+def make_event(
+    reason: str,
+    pod_name: str,
+    kind: str = "Pod",
+    timestamp: str = "2026-06-20T12:00:00Z",
+):
     return {
         "reason": reason,
-        "involvedObject": {"kind": kind, "name": pod_name, "namespace": "test-ns"},
+        "involvedObject": {
+            "kind": kind,
+            "name": pod_name,
+            "namespace": "test-ns",
+        },
         "eventTime": timestamp,
         "lastTimestamp": timestamp,
     }
@@ -27,7 +36,16 @@ def make_event(reason: str, pod_name: str, kind: str = "Pod", timestamp: str = "
 def make_pod_item(name: str, labels=None):
     return {
         "metadata": {"name": name, "labels": labels or {}},
-        "status": {"containerStatuses": [{"name": "main", "state": {"running": {}}, "lastState": {}, "restartCount": 0}]},
+        "status": {
+            "containerStatuses": [
+                {
+                    "name": "main",
+                    "state": {"running": {}},
+                    "lastState": {},
+                    "restartCount": 0,
+                }
+            ]
+        },
     }
 
 
@@ -44,7 +62,10 @@ def test_non_pod_events_are_ignored(mock_crash, mock_oom, mock_pods, mock_events
     ]
     mock_pods.return_value = [make_pod_item("managed-upgrade-operator-xyz")]
 
-    result = namespace_worker_oc("ctx", "openshift-managed-upgrade-operator", retries=1, oc_timeout_seconds=10)
+    result = namespace_worker_oc(
+        "ctx", "openshift-managed-upgrade-operator",
+        retries=1, oc_timeout_seconds=10,
+    )
 
     assert result is not None, "Should find the Pod event"
     assert "managed-upgrade-operator-xyz" in result, "Pod event should be included"
@@ -69,7 +90,9 @@ def test_event_only_pods_not_in_listing_are_dropped(mock_crash, mock_oom, mock_p
 
     assert result is not None
     assert "real-pod-abc12" in result, "Pod that exists in listing should be kept"
-    assert "ghost-pod-from-stale-event" not in result, "Event-only pod not in listing must be dropped"
+    assert "ghost-pod-from-stale-event" not in result, (
+        "Event-only pod not in listing must be dropped"
+    )
     print("PASS: Event-only pods not in listing are correctly dropped")
 
 
@@ -81,7 +104,14 @@ def test_pod_status_detected_pods_are_kept(mock_crash, mock_oom, mock_pods, mock
     """Pods found via pod status (oc_get_pods) should always be kept."""
     mock_events.return_value = []
     mock_pods.return_value = [make_pod_item("crash-pod-xyz")]
-    mock_oom.return_value = [{"pod": "crash-pod-xyz", "timestamp": "2026-06-20T12:00:00Z", "application": "", "component": ""}]
+    mock_oom.return_value = [
+        {
+            "pod": "crash-pod-xyz",
+            "timestamp": "2026-06-20T12:00:00Z",
+            "application": "",
+            "component": "",
+        }
+    ]
 
     result = namespace_worker_oc("ctx", "test-ns", retries=1, oc_timeout_seconds=10)
 


### PR DESCRIPTION
## Summary
- Filter events by `involvedObject.kind == "Pod"` to ignore Node, DaemonSet, and other non-Pod events that were incorrectly treated as pod incidents
- Cross-validate event-discovered pods against the actual pod listing for the namespace — pods found only via events but missing from `oc get pods` are dropped
- Prevents misattribution like `splunkforwarder-ds` (actually in `openshift-security`) being reported under `openshift-managed-upgrade-operator` (KONFLUX-14702)

## Background

The OOM/CrashLoop detector scans Kubernetes events per namespace. Previously, it used `involvedObject.name` from events without checking `involvedObject.kind`, treating every event's involved object as a Pod. This caused two problems:

1. **Non-Pod events** (e.g. DaemonSet, Node) were processed as if they were Pod events
2. **Stale events** referencing pods that no longer exist in the namespace could produce false positives with wrong namespace attribution

The downstream Jira automation then created tickets with incorrect namespace routing, leading to misdirected support cases.

## Test plan
- [x] Added `test_namespace_misattribution.py` with 4 unit tests covering:
  - Non-Pod events are ignored
  - Event-only ghost pods not in listing are dropped
  - Pod-status-detected pods are preserved (no false negatives)
  - Real event pods present in listing are preserved
- [x] Verified existing `test_artifact_validation.py` still passes
- [x] Live-tested against `stone-prd-rh01` cluster: `managed-upgrade-operator` correctly detected in `openshift-managed-upgrade-operator`, no splunkforwarder cross-contamination

🤖 Generated with [Claude Code](https://claude.com/claude-code)