### PR TITLE
fix: show accessible/total cluster count in connectivity report

### DIFF
--- a/tools/tasks-and-steps-resource-analyzer/analyze_resource_limits.py
+++ b/tools/tasks-and-steps-resource-analyzer/analyze_resource_limits.py
@@ -4747,13 +4747,9 @@ Examples:
         accessible_count = sum(1 for _, connected, _ in connectivity_report if connected)
         total_count = len(connectivity_report)
 
-        cluster_summary = (
-            f"{accessible_count}/{total_count} clusters are accessible"
-        )
+        cluster_summary = f"{accessible_count}/{total_count} clusters are accessible"
         if not all_connected:
-            print(
-                f"\nWARNING: {cluster_summary}.", file=sys.stderr
-            )
+            print(f"\nWARNING: {cluster_summary}.", file=sys.stderr)
             print(
                 "  Data collection may fail for unreachable clusters.",
                 file=sys.stderr,

--- a/tools/tasks-and-steps-resource-analyzer/analyze_resource_limits.py
+++ b/tools/tasks-and-steps-resource-analyzer/analyze_resource_limits.py
@@ -4744,15 +4744,18 @@ Examples:
             status = "✓" if connected else "✗"
             print(f"  {status} {cluster}: {message}", file=sys.stderr)
 
+        accessible_count = sum(1 for _, connected, _ in connectivity_report if connected)
+        total_count = len(connectivity_report)
+
         if not all_connected:
-            print("\nWARNING: Some clusters are not accessible.", file=sys.stderr)
+            print(f"\nWARNING: {accessible_count}/{total_count} clusters are accessible.", file=sys.stderr)
             if args.dry_run:
-                print("  Data collection may fail for these clusters.", file=sys.stderr)
+                print("  Data collection may fail for unreachable clusters.", file=sys.stderr)
             else:
-                print("  Data collection may fail for these clusters.", file=sys.stderr)
+                print("  Data collection may fail for unreachable clusters.", file=sys.stderr)
                 print("  Continuing with accessible clusters only...", file=sys.stderr)
         else:
-            print("\n✓ All clusters are accessible", file=sys.stderr)
+            print(f"\n✓ {accessible_count}/{total_count} clusters are accessible", file=sys.stderr)
 
         # Always prompt for confirmation
         # For display, ensure steps have 'step-' prefix (for consistency with wrapper script format)

--- a/tools/tasks-and-steps-resource-analyzer/analyze_resource_limits.py
+++ b/tools/tasks-and-steps-resource-analyzer/analyze_resource_limits.py
@@ -4747,15 +4747,24 @@ Examples:
         accessible_count = sum(1 for _, connected, _ in connectivity_report if connected)
         total_count = len(connectivity_report)
 
+        cluster_summary = (
+            f"{accessible_count}/{total_count} clusters are accessible"
+        )
         if not all_connected:
-            print(f"\nWARNING: {accessible_count}/{total_count} clusters are accessible.", file=sys.stderr)
-            if args.dry_run:
-                print("  Data collection may fail for unreachable clusters.", file=sys.stderr)
-            else:
-                print("  Data collection may fail for unreachable clusters.", file=sys.stderr)
-                print("  Continuing with accessible clusters only...", file=sys.stderr)
+            print(
+                f"\nWARNING: {cluster_summary}.", file=sys.stderr
+            )
+            print(
+                "  Data collection may fail for unreachable clusters.",
+                file=sys.stderr,
+            )
+            if not args.dry_run:
+                print(
+                    "  Continuing with accessible clusters only...",
+                    file=sys.stderr,
+                )
         else:
-            print(f"\n✓ {accessible_count}/{total_count} clusters are accessible", file=sys.stderr)
+            print(f"\n✓ {cluster_summary}", file=sys.stderr)
 
         # Always prompt for confirmation
         # For display, ensure steps have 'step-' prefix (for consistency with wrapper script format)


### PR DESCRIPTION
## Summary

Shows an explicit cluster count (`<X>/<N> clusters are accessible`) instead of the generic "All clusters are accessible" message in the connectivity report.

## Changes

- **All accessible**: `✓ All clusters are accessible` → `✓ 12/12 clusters are accessible`
- **Some unreachable**: `WARNING: Some clusters are not accessible.` → `WARNING: 10/12 clusters are accessible.`
- Also improved wording from "these clusters" to "unreachable clusters" in the warning details

## Example output

```
Cluster Connectivity Report:
  ✓ kflux-ocp-p01: Connected
  ✓ kflux-osp-p01: Connected
  ...
  ✗ stone-stg-rh01: Connection refused

WARNING: 10/12 clusters are accessible.
  Data collection may fail for unreachable clusters.
  Continuing with accessible clusters only...
```

Signed-off-by: Subrata Modak <smodak@redhat.com>

Made with [Cursor](https://cursor.com)