### PR TITLE
feat: Add kflux-osp-p01 to loadtest probe dashboards

### DIFF
--- a/grafonnet-workdir/src/loadtest-probe-multiarch.jsonnet
+++ b/grafonnet-workdir/src/loadtest-probe-multiarch.jsonnet
@@ -4,6 +4,7 @@ local probes = import 'probes.libsonnet';
 local memberClusters = [
   'https://api.kflux-fedora-01.84db.p1.openshiftapps.com:6443/',
   'https://api.kflux-ocp-p01.7ayg.p1.openshiftapps.com:6443/',
+  'https://api.kflux-osp-p01.yt45.p1.openshiftapps.com:6443/',
   'https://api.kflux-prd-rh02.0fk9.p1.openshiftapps.com:6443/',
   'https://api.kflux-prd-rh03.nnv1.p1.openshiftapps.com:6443/',
   'https://api.kflux-rhel-p01.fc38.p1.openshiftapps.com:6443/',

--- a/grafonnet-workdir/src/loadtest-probe.jsonnet
+++ b/grafonnet-workdir/src/loadtest-probe.jsonnet
@@ -4,6 +4,7 @@ local probes = import 'probes.libsonnet';
 local memberClusters = [
   'https://api.kflux-fedora-01.84db.p1.openshiftapps.com:6443/',
   'https://api.kflux-ocp-p01.7ayg.p1.openshiftapps.com:6443/',
+  'https://api.kflux-osp-p01.yt45.p1.openshiftapps.com:6443/',
   'https://api.kflux-prd-rh02.0fk9.p1.openshiftapps.com:6443/',
   'https://api.kflux-prd-rh03.nnv1.p1.openshiftapps.com:6443/',
   'https://api.kflux-rhel-p01.fc38.p1.openshiftapps.com:6443/',


### PR DESCRIPTION
Part 2 of https://redhat.atlassian.net/browse/KONFLUX-14567
- Updated [loadtest-probe.jsonnet](https://github.com/konflux-ci/perfscale/blob/main/grafonnet-workdir/src/loadtest-probe.jsonnet#L4) and [loadtest-probe-multiarch.jsonnet](https://github.com/konflux-ci/perfscale/blob/main/grafonnet-workdir/src/loadtest-probe-multiarch.jsonnet#L4) with the new API server name for the kflux-osp-p01 cluster.

This is connected to https://gitlab.cee.redhat.com/redhat-performance/ci-configs/-/merge_requests/629